### PR TITLE
PDF417: Added configurable aspect ratio, errorCorrection level=AUTO.

### DIFF
--- a/Source/lib/EncodeHintType.cs
+++ b/Source/lib/EncodeHintType.cs
@@ -66,6 +66,12 @@ namespace ZXing
       MARGIN,
 
       /// <summary>
+      /// Specifies the aspect ratio to use.  Default is 4.
+      /// type: <see cref="ZXing.PDF417.Internal.PDF417AspectRatio" />, or 1-4.
+      /// </summary>
+      PDF417_ASPECT_RATIO,
+
+      /// <summary>
       /// Specifies whether to use compact mode for PDF417
       /// type: <see cref="System.Boolean" />, or "true" or "false"
       /// <see cref="System.String" /> value

--- a/Source/lib/pdf417/encoder/PDF417.cs
+++ b/Source/lib/pdf417/encoder/PDF417.cs
@@ -745,7 +745,7 @@ namespace ZXing.PDF417.Internal
             int newRatio = 4;
                 
             //Integer division.
-            if (dimMaxRows > calculatedRows)
+            if (dimMaxRows >= calculatedRows)
                 newRatio = Math.Min(dimMaxRows / calculatedRows, newRatio);
             aspectRatio = newRatio;
             dimMaxRows = Math.Min(shortDimension/aspectRatio, maxRows);

--- a/Source/lib/pdf417/encoder/PDF417.cs
+++ b/Source/lib/pdf417/encoder/PDF417.cs
@@ -736,7 +736,7 @@ namespace ZXing.PDF417.Internal
          int dimMaxCols = Math.Min((longDimension- START_STOP_WIDTH) / COLUMN_WIDTH, maxCols);
          int dimMaxRows = Math.Min(shortDimension/aspectRatio, maxRows);
          int calculatedRows = calculateNumberOfRows(sourceCodeWords, errorCorrectionCodeWords, dimMaxCols);
-         bool canFit = calculatedRows < dimMaxRows;
+         bool canFit = calculatedRows <= dimMaxRows;
 
          //Set the aspectRatio if AUTO.
          if (aspectRatio>=(int)PDF417AspectRatio.AUTO)

--- a/Source/lib/pdf417/encoder/PDF417.cs
+++ b/Source/lib/pdf417/encoder/PDF417.cs
@@ -518,11 +518,12 @@ namespace ZXing.PDF417.Internal
                   0x10794, 0x10fb4, 0x10792, 0x10fb2, 0x1c7ea
                }
          };
-
+      private const int START_STOP_WIDTH = 69; //TODO: Adjust this for compact==true.  PDF417 compact seems to be ~34 in width.
+      private const int COLUMN_WIDTH = 17;
       private const float PREFERRED_RATIO = 3.0f;
       private const float DEFAULT_MODULE_WIDTH = 0.357f; //1px in mm
       private const float HEIGHT = 2.0f; //mm
-
+    
       private BarcodeMatrix barcodeMatrix;
       private bool compact;
       private Compaction compaction;
@@ -546,8 +547,8 @@ namespace ZXing.PDF417.Internal
          disableEci = false;
          minCols = 2;
          maxCols = 30;
-         maxRows = 30;
-         minRows = 2;
+         maxRows = 90;
+         minRows = 3;
       }
 
       internal BarcodeMatrix BarcodeMatrix
@@ -675,15 +676,16 @@ namespace ZXing.PDF417.Internal
       /// </summary>
       /// <param name="msg">the message to encode</param>
       /// <param name="errorCorrectionLevel">PDF417 error correction level to use</param>
-      internal void generateBarcodeLogic(String msg, int errorCorrectionLevel)
+      internal void generateBarcodeLogic(String msg, int errorCorrectionLevel, int longDimension, int shortDimension, ref int aspectRatio)
       {
 
          //1. step: High-level encoding
-         int errorCorrectionCodeWords = PDF417ErrorCorrection.getErrorCorrectionCodewordCount(errorCorrectionLevel);
          String highLevel = PDF417HighLevelEncoder.encodeHighLevel(msg, compaction, encoding, disableEci);
          int sourceCodeWords = highLevel.Length;
+         errorCorrectionLevel = PDF417ErrorCorrection.getErrorCorrectionLevel(errorCorrectionLevel,sourceCodeWords);
+         int errorCorrectionCodeWords = PDF417ErrorCorrection.getErrorCorrectionCodewordCount(errorCorrectionLevel);
 
-         int[] dimension = determineDimensions(sourceCodeWords, errorCorrectionCodeWords);
+         int[] dimension = determineDimensions(sourceCodeWords, errorCorrectionCodeWords, longDimension, shortDimension, ref aspectRatio);
 
          int cols = dimension[0];
          int rows = dimension[1];
@@ -722,13 +724,36 @@ namespace ZXing.PDF417.Internal
       /// </summary>
       /// <param name="sourceCodeWords">number of code words</param>
       /// <param name="errorCorrectionCodeWords">number of error correction code words</param>
+      /// <param name="longDimension">The longest dimension of the barcode, used for columns</param>
+      /// <param name="shortDimension">The short dimension of the barcode, used for rows</param>
+      /// <param name="aspectRatio">The height of a row, will alter this parameter if aspectRatio>4 (aspectRatio==AUTO)</param>
       /// <returns>dimension object containing cols as width and rows as height</returns>
-      private int[] determineDimensions(int sourceCodeWords, int errorCorrectionCodeWords)
+      private int[] determineDimensions(int sourceCodeWords, int errorCorrectionCodeWords, int longDimension, int shortDimension, ref int aspectRatio)
       {
          float ratio = 0.0f;
          int[] dimension = null;
 
-         for (int cols = minCols; cols <= maxCols; cols++)
+         int dimMaxCols = Math.Min((longDimension- START_STOP_WIDTH) / COLUMN_WIDTH, maxCols);
+         int dimMaxRows = Math.Min(shortDimension/aspectRatio, maxRows);
+         int calculatedRows = calculateNumberOfRows(sourceCodeWords, errorCorrectionCodeWords, dimMaxCols);
+         bool canFit = calculatedRows < dimMaxRows;
+
+         //Set the aspectRatio if AUTO.
+         if (aspectRatio>=(int)PDF417AspectRatio.AUTO)
+         {
+            dimMaxRows = Math.Min(shortDimension, maxRows);
+            int newRatio = 4;
+                
+            //Integer division.
+            if (dimMaxRows > calculatedRows)
+                newRatio = Math.Min(dimMaxRows / calculatedRows, newRatio);
+            aspectRatio = newRatio;
+            dimMaxRows = Math.Min(shortDimension/aspectRatio, maxRows);
+            canFit = calculatedRows <= dimMaxRows;
+         }
+
+
+         for (int cols = minCols; cols <= maxCols && (!canFit || cols<=dimMaxCols); cols++)
          {
 
             int rows = calculateNumberOfRows(sourceCodeWords, errorCorrectionCodeWords, cols);
@@ -738,7 +763,7 @@ namespace ZXing.PDF417.Internal
                break;
             }
 
-            if (rows > maxRows)
+            if (rows > maxRows || (rows > dimMaxRows && canFit))
             {
                continue;
             }

--- a/Source/lib/pdf417/encoder/PDF417AspectRatio.cs
+++ b/Source/lib/pdf417/encoder/PDF417AspectRatio.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * Copyright ZXing Authors in part
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace ZXing.PDF417.Internal
+{
+    /// <summary>
+    /// defines the level of the error correction / count of error correction codewords
+    /// </summary>
+    public enum PDF417AspectRatio
+    {
+        A1 = 1,
+        A2,
+        A3,
+        A4,
+        AUTO
+    }
+}

--- a/Source/lib/pdf417/encoder/PDF417EncodingOptions.cs
+++ b/Source/lib/pdf417/encoder/PDF417EncodingOptions.cs
@@ -102,6 +102,30 @@ namespace ZXing.PDF417
       }
 
       /// <summary>
+      /// Specifies what degree of error correction to use
+      /// </summary>
+      public PDF417AspectRatio AspectRatio
+      {
+          get
+          {
+              if (Hints.ContainsKey(EncodeHintType.PDF417_ASPECT_RATIO))
+              {
+                  var value = Hints[EncodeHintType.PDF417_ASPECT_RATIO];
+                  if (value is PDF417AspectRatio)
+                  {
+                      return (PDF417AspectRatio)value;
+                  }
+                  if (value is int)
+                  {
+                      return (PDF417AspectRatio)Enum.Parse(typeof(PDF417AspectRatio), value.ToString(), true);
+                  }
+              }
+                return PDF417AspectRatio.A4;
+          }
+          set { Hints[EncodeHintType.PDF417_ASPECT_RATIO] = value; }
+        }
+
+      /// <summary>
       /// Specifies what character encoding to use where applicable (type {@link String})
       /// </summary>
       public string CharacterSet

--- a/Source/lib/pdf417/encoder/PDF417ErrorCorrection.cs
+++ b/Source/lib/pdf417/encoder/PDF417ErrorCorrection.cs
@@ -154,11 +154,25 @@ namespace ZXing.PDF417.Internal
       /// <returns>the number of codewords generated for error correction</returns>
       internal static int getErrorCorrectionCodewordCount(int errorCorrectionLevel)
       {
-         if (errorCorrectionLevel < 0 || errorCorrectionLevel > 8)
-         {
-            throw new ArgumentException("Error correction level must be between 0 and 8!");
-         }
-         return 1 << (errorCorrectionLevel + 1);
+          if (errorCorrectionLevel < 0 || errorCorrectionLevel > 8)
+          {
+              throw new ArgumentException("Error correction level must be between 0 and 8!");
+          }
+          return 1 << (errorCorrectionLevel + 1);
+      }
+
+      /// <summary>
+      /// Determines the error correction level for AUTO
+      /// </summary>
+      /// <param name="errorCorrectionLevel">The error correction level (0-9)</param>
+      /// <param name="sourceCodeWords">The number of codewords for AUTO errorCorrectionLevel</param>
+      /// <returns>the number of codewords generated for error correction</returns>
+      internal static int getErrorCorrectionLevel(int errorCorrectionLevel, int sourceCodeWords)
+      {
+            if (errorCorrectionLevel == (int)PDF417ErrorCorrectionLevel.AUTO)
+                return getRecommendedMinimumErrorCorrectionLevel(sourceCodeWords);
+            else
+                return errorCorrectionLevel;
       }
 
       /// <summary>
@@ -200,6 +214,8 @@ namespace ZXing.PDF417.Internal
       /// <returns>the String representing the error correction codewords</returns>
       internal static String generateErrorCorrection(String dataCodewords, int errorCorrectionLevel)
       {
+        if (errorCorrectionLevel == (int)PDF417ErrorCorrectionLevel.AUTO)
+            errorCorrectionLevel = getRecommendedMinimumErrorCorrectionLevel(errorCorrectionLevel);
          int k = getErrorCorrectionCodewordCount(errorCorrectionLevel);
          char[] e = new char[k];
          int sld = dataCodewords.Length;
@@ -244,6 +260,7 @@ namespace ZXing.PDF417.Internal
       L5,
       L6,
       L7,
-      L8
+      L8,
+      AUTO
    }
 }

--- a/Source/lib/zxing.net4.0.csproj
+++ b/Source/lib/zxing.net4.0.csproj
@@ -274,6 +274,7 @@
     <Compile Include="pdf417\decoder\PDF417CodewordDecoder.cs" />
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\PDF417EncodingOptions.cs" />
     <Compile Include="pdf417\PDF417Common.cs" />
     <Compile Include="pdf417\PDF417ResultMetadata.cs" />


### PR DESCRIPTION
Re-did the PDF417 height/width feature then waited until the changes finished going through our own internal testing.  

PDF417Encoder will now make a best effort to fit within the specified height/width parameters.  If that is not possible, it will return to default behavior and build the barcode according to the standard 1/3 ratio.  Also added Aspect Ratio as a parameter, default is 4 but can be set to AUTO.  When AUTO, it will change to the maximum size that will still fit within the specified height/width parameters.  ErrorCorrection also got an AUTO setting.  When used, errorCorrection will be set via getRecommendedMinimumErrorCorrectionLevel(). 