### PR TITLE
Fixed missing part of texture, when width is a power of two

### DIFF
--- a/Source/lib/unity/Color32Renderer.cs
+++ b/Source/lib/unity/Color32Renderer.cs
@@ -80,7 +80,8 @@ namespace ZXing
          var offset = matrix.Height - 1;
          var foreground = Foreground;
          var background = Background;
-         var bitRowRemainder = 32 - (32 - matrix.Width % 32);
+         var divisionLeftover = matrix.Width % 32;
+         var bitRowRemainder = divisionLeftover > 0 ? divisionLeftover : 32;
 
          for (int y = 0; y < matrix.Height; y++)
          {


### PR DESCRIPTION
Old implementation at commit a8d88aeeebbf69fcdffe9770524368beb636dfd3 of Color32 Renderer was failing to draw the rightmost 32 pixels of a texture, if it's width was the power of two (64 px, 128px, 256px, and so on).
# Actual generated image:
![actual](https://user-images.githubusercontent.com/1696484/35489145-9087c9f8-049b-11e8-9482-aa910f7c2748.png)
# Expected image:
![expected](https://user-images.githubusercontent.com/1696484/35489146-90a3ceaa-049b-11e8-86f7-3719c8b1b752.png)    
Example project, that demonstrates the issue:
[BugExample.zip](https://github.com/micjahn/ZXing.Net/files/1671817/BugExample.zip)

