### PR TITLE
Changed PDF417 to generate barcodes based on specified height/width

### DIFF
--- a/Source/lib/EncodeHintType.cs
+++ b/Source/lib/EncodeHintType.cs
@@ -66,6 +66,12 @@ namespace ZXing
       MARGIN,
 
       /// <summary>
+      /// Specifies the aspect ratio to use.  Default is 4.
+      /// type: <see cref="ZXing.PDF417.Internal.PDF417AspectRatio" />, or 1-4.
+      /// </summary>
+      PDF417_ASPECT_RATIO,
+
+      /// <summary>
       /// Specifies whether to use compact mode for PDF417
       /// type: <see cref="System.Boolean" />, or "true" or "false"
       /// <see cref="System.String" /> value

--- a/Source/lib/pdf417/encoder/BarcodeMatrix.cs
+++ b/Source/lib/pdf417/encoder/BarcodeMatrix.cs
@@ -27,20 +27,21 @@ namespace ZXing.PDF417.Internal
       private int currentRow;
       private readonly int height;
       private readonly int width;
+      internal const int COLUMN_WIDTH = 17;
 
       /// <summary>
       /// <param name="height">the height of the matrix (Rows)</param>
       /// <param name="width">the width of the matrix (Cols)</param>
       /// </summary>
-      internal BarcodeMatrix(int height, int width)
+      internal BarcodeMatrix(int height, int width, bool compact)
       {
          matrix = new BarcodeRow[height];
          //Initializes the array to the correct width
          for (int i = 0, matrixLength = matrix.Length; i < matrixLength; i++)
          {
-            matrix[i] = new BarcodeRow((width + 4)*17 + 1);
+            matrix[i] = new BarcodeRow(width * COLUMN_WIDTH + (2*COLUMN_WIDTH) + (compact?0:2)*COLUMN_WIDTH + 1);
          }
-         this.width = width*17;
+         this.width = width*COLUMN_WIDTH;
          this.height = height;
          this.currentRow = -1;
       }

--- a/Source/lib/pdf417/encoder/BarcodeMatrix.cs
+++ b/Source/lib/pdf417/encoder/BarcodeMatrix.cs
@@ -39,6 +39,8 @@ namespace ZXing.PDF417.Internal
          //Initializes the array to the correct width
          for (int i = 0, matrixLength = matrix.Length; i < matrixLength; i++)
          {
+            //Matrix width is: Cols*COLUMN_WIDTH + <PDF417_START_COLS> + <PDF417_END_COLS> + 1
+            //When compact=true, the END_COLS are omitted.
             matrix[i] = new BarcodeRow(width * COLUMN_WIDTH + (2*COLUMN_WIDTH) + (compact?0:2)*COLUMN_WIDTH + 1);
          }
          this.width = width*COLUMN_WIDTH;

--- a/Source/lib/pdf417/encoder/PDF417AspectRatio.cs
+++ b/Source/lib/pdf417/encoder/PDF417AspectRatio.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * Copyright ZXing Authors in part
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace ZXing.PDF417.Internal
+{
+    /// <summary>
+    /// defines the level of the error correction / count of error correction codewords
+    /// </summary>
+    public enum PDF417AspectRatio
+    {
+        A1 = 1,
+        A2,
+        A3,
+        A4,
+        AUTO
+    }
+}

--- a/Source/lib/pdf417/encoder/PDF417EncodingOptions.cs
+++ b/Source/lib/pdf417/encoder/PDF417EncodingOptions.cs
@@ -102,6 +102,30 @@ namespace ZXing.PDF417
       }
 
       /// <summary>
+      /// Specifies what degree of error correction to use
+      /// </summary>
+      public PDF417AspectRatio AspectRatio
+      {
+          get
+          {
+              if (Hints.ContainsKey(EncodeHintType.PDF417_ASPECT_RATIO))
+              {
+                  var value = Hints[EncodeHintType.PDF417_ASPECT_RATIO];
+                  if (value is PDF417AspectRatio)
+                  {
+                      return (PDF417AspectRatio)value;
+                  }
+                  if (value is int)
+                  {
+                      return (PDF417AspectRatio)Enum.Parse(typeof(PDF417AspectRatio), value.ToString(), true);
+                  }
+              }
+                return PDF417AspectRatio.A4;
+          }
+          set { Hints[EncodeHintType.PDF417_ASPECT_RATIO] = value; }
+        }
+
+      /// <summary>
       /// Specifies what character encoding to use where applicable (type {@link String})
       /// </summary>
       public string CharacterSet

--- a/Source/lib/pdf417/encoder/PDF417ErrorCorrection.cs
+++ b/Source/lib/pdf417/encoder/PDF417ErrorCorrection.cs
@@ -154,11 +154,25 @@ namespace ZXing.PDF417.Internal
       /// <returns>the number of codewords generated for error correction</returns>
       internal static int getErrorCorrectionCodewordCount(int errorCorrectionLevel)
       {
-         if (errorCorrectionLevel < 0 || errorCorrectionLevel > 8)
-         {
-            throw new ArgumentException("Error correction level must be between 0 and 8!");
-         }
-         return 1 << (errorCorrectionLevel + 1);
+          if (errorCorrectionLevel < 0 || errorCorrectionLevel > 8)
+          {
+              throw new ArgumentException("Error correction level must be between 0 and 8!");
+          }
+          return 1 << (errorCorrectionLevel + 1);
+      }
+
+      /// <summary>
+      /// Determines the error correction level for AUTO
+      /// </summary>
+      /// <param name="errorCorrectionLevel">The error correction level (0-9)</param>
+      /// <param name="sourceCodeWords">The number of codewords for AUTO errorCorrectionLevel</param>
+      /// <returns>the number of codewords generated for error correction</returns>
+      internal static int getErrorCorrectionLevel(int errorCorrectionLevel, int sourceCodeWords)
+      {
+            if (errorCorrectionLevel == (int)PDF417ErrorCorrectionLevel.AUTO)
+                return getRecommendedMinimumErrorCorrectionLevel(sourceCodeWords);
+            else
+                return errorCorrectionLevel;
       }
 
       /// <summary>
@@ -169,10 +183,6 @@ namespace ZXing.PDF417.Internal
       /// <returns>the recommended minimum error correction level</returns>
       internal static int getRecommendedMinimumErrorCorrectionLevel(int n)
       {
-         if (n <= 0)
-         {
-            throw new ArgumentException("n must be > 0");
-         }
          if (n <= 40)
          {
             return 2;
@@ -200,6 +210,8 @@ namespace ZXing.PDF417.Internal
       /// <returns>the String representing the error correction codewords</returns>
       internal static String generateErrorCorrection(String dataCodewords, int errorCorrectionLevel)
       {
+        if (errorCorrectionLevel == (int)PDF417ErrorCorrectionLevel.AUTO)
+            errorCorrectionLevel = getRecommendedMinimumErrorCorrectionLevel(errorCorrectionLevel);
          int k = getErrorCorrectionCodewordCount(errorCorrectionLevel);
          char[] e = new char[k];
          int sld = dataCodewords.Length;
@@ -244,6 +256,7 @@ namespace ZXing.PDF417.Internal
       L5,
       L6,
       L7,
-      L8
+      L8,
+      AUTO
    }
 }

--- a/Source/lib/uwp/zxing.uwp.csproj
+++ b/Source/lib/uwp/zxing.uwp.csproj
@@ -785,6 +785,9 @@
     <Compile Include="..\pdf417\detector\PDF417DetectorResult.cs">
       <Link>pdf417\detector\PDF417DetectorResult.cs</Link>
     </Compile>
+    <Compile Include="..\pdf417\encoder\PDF417AspectRatio.cs">
+      <Link>pdf417\encoder\PDF417AspectRatio.cs</Link>
+    </Compile>
     <Compile Include="..\pdf417\encoder\BarcodeMatrix.cs">
       <Link>pdf417\encoder\BarcodeMatrix.cs</Link>
     </Compile>

--- a/Source/lib/zxing.ce2.0.csproj
+++ b/Source/lib/zxing.ce2.0.csproj
@@ -291,6 +291,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.ce3.5.csproj
+++ b/Source/lib/zxing.ce3.5.csproj
@@ -290,6 +290,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.ios.csproj
+++ b/Source/lib/zxing.ios.csproj
@@ -275,6 +275,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.monoandroid.csproj
+++ b/Source/lib/zxing.monoandroid.csproj
@@ -277,6 +277,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.monotouch.csproj
+++ b/Source/lib/zxing.monotouch.csproj
@@ -282,6 +282,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.net2.0.csproj
+++ b/Source/lib/zxing.net2.0.csproj
@@ -297,6 +297,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.net3.5.csproj
+++ b/Source/lib/zxing.net3.5.csproj
@@ -287,6 +287,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.net4.0.csproj
+++ b/Source/lib/zxing.net4.0.csproj
@@ -274,6 +274,7 @@
     <Compile Include="pdf417\decoder\PDF417CodewordDecoder.cs" />
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\PDF417EncodingOptions.cs" />
     <Compile Include="pdf417\PDF417Common.cs" />
     <Compile Include="pdf417\PDF417ResultMetadata.cs" />

--- a/Source/lib/zxing.net4.5.csproj
+++ b/Source/lib/zxing.net4.5.csproj
@@ -282,6 +282,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.net4.6.csproj
+++ b/Source/lib/zxing.net4.6.csproj
@@ -282,6 +282,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.net4.7.csproj
+++ b/Source/lib/zxing.net4.7.csproj
@@ -278,6 +278,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.portable.csproj
+++ b/Source/lib/zxing.portable.csproj
@@ -271,6 +271,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.sl4.csproj
+++ b/Source/lib/zxing.sl4.csproj
@@ -306,6 +306,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.sl5.csproj
+++ b/Source/lib/zxing.sl5.csproj
@@ -308,6 +308,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.unity.csproj
+++ b/Source/lib/zxing.unity.csproj
@@ -287,6 +287,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.winrt.csproj
+++ b/Source/lib/zxing.winrt.csproj
@@ -359,6 +359,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.wp7.0.csproj
+++ b/Source/lib/zxing.wp7.0.csproj
@@ -289,6 +289,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.wp7.1.csproj
+++ b/Source/lib/zxing.wp7.1.csproj
@@ -290,6 +290,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />

--- a/Source/lib/zxing.wp8.0.csproj
+++ b/Source/lib/zxing.wp8.0.csproj
@@ -368,6 +368,7 @@
     <Compile Include="pdf417\decoder\PDF417ScanningDecoder.cs" />
     <Compile Include="pdf417\detector\Detector.cs" />
     <Compile Include="pdf417\detector\PDF417DetectorResult.cs" />
+    <Compile Include="pdf417\encoder\PDF417AspectRatio.cs" />
     <Compile Include="pdf417\encoder\BarcodeMatrix.cs" />
     <Compile Include="pdf417\encoder\BarcodeRow.cs" />
     <Compile Include="pdf417\encoder\Compaction.cs" />


### PR DESCRIPTION
Changed PDF417 to generate barcodes based on specified height/width if possible, otherwise will generate a standard PDF417 barcode.

Added PDF417AspectRatio, when set, changes the height of a row from the default of 4 to specified value.  AUTO will use the largest value possible that fits.

Added PDF417ErrorCorrection.AUTO, when set, uses the minimumErrorCorrectionLevel for the specified text per ISO/IEC 15438:2001(E).

Minor optimization for BarcodeMatrix, now generates a smaller matrix for PDF417.compact instead of 34px of white space on the right.