### PR TITLE
BigIntegerException: fix build

### DIFF
--- a/Source/lib/common/BigInteger/BigIntegerException.cs
+++ b/Source/lib/common/BigInteger/BigIntegerException.cs
@@ -6,7 +6,7 @@ namespace BigIntegerLibrary
     /// <summary>
     /// BigInteger-related exception class.
     /// </summary>
-    [Serializable]
+    [System.Serializable]
     public sealed class BigIntegerException : Exception
     {
         /// <summary>


### PR DESCRIPTION
When compiling in certain circumstances, this file could get this
build error:

lib/common/BigInteger/BigIntegerException.cs(5,5):
Error CS0104: 'Serializable' is an ambiguous reference between
'ZXing.SerializableAttribute' and 'System.SerializableAttribute'
(CS0104)