### PR TITLE
Fix MIXED mode table and OR bit operator

### DIFF
--- a/Source/lib/aztec/decoder/Decoder.cs
+++ b/Source/lib/aztec/decoder/Decoder.cs
@@ -55,8 +55,8 @@ namespace ZXing.Aztec.Internal
         private static readonly String[] MIXED_TABLE =
         {
          "CTRL_PS", " ", "\x1", "\x2", "\x3", "\x4", "\x5", "\x6", "\x7", "\b", "\t", "\n",
-         "\xD", "\f", "\r", "\x21", "\x22", "\x23", "\x24", "\x25", "@", "\\", "^", "_",
-         "`", "|", "~", "\xB1", "CTRL_LL", "CTRL_UL", "CTRL_PL", "CTRL_BS"
+         "\xB", "\f", "\r", "\x1B", "\x1C", "\x1D", "\x1E", "\x1F", "@", "\\", "^", "_",
+         "`", "|", "~", "\x7F", "CTRL_LL", "CTRL_UL", "CTRL_PL", "CTRL_BS"
       };
 
         private static readonly String[] PUNCT_TABLE =
@@ -406,7 +406,7 @@ namespace ZXing.Aztec.Internal
                 res <<= 1;
                 if (rawbits[i])
                 {
-                    res++;
+                    res |= 1;
                 }
             }
             return res;


### PR DESCRIPTION
String constants are different [in this repo](https://github.com/micjahn/ZXing.Net/blob/master/Source/lib/aztec/decoder/Decoder.cs#L55) when compared to constants used in the [Java version](https://github.com/zxing/zxing/blob/master/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java#L56). The escaped Java string constants `"\13"`, `"\33"`, `"\34"`, `"\35"`, `"\36"`, `"\37"`, and `"\177"`, are [in octal](https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.10.6), not in decimal.

The change from increment to or-set should have no functional difference due to the way the outer loop is constructed, but it could lead to nasty bugs if the something around it changes. The Java version also uses OR-set.