### PR TITLE
Use interfaces for ImageMagick

### DIFF
--- a/Source/Bindings/ZXing.Magick/BarcodeReader.Extensions.cs
+++ b/Source/Bindings/ZXing.Magick/BarcodeReader.Extensions.cs
@@ -31,7 +31,7 @@ namespace ZXing
         /// <param name="reader"></param>
         /// <param name="image"></param>
         /// <returns></returns>
-        public static Result Decode(this IBarcodeReaderGeneric reader, MagickImage image)
+        public static Result Decode(this IBarcodeReaderGeneric reader, IMagickImage image)
         {
             var luminanceSource = new MagickImageLuminanceSource(image);
             return reader.Decode(luminanceSource);
@@ -43,7 +43,7 @@ namespace ZXing
         /// <param name="reader"></param>
         /// <param name="image"></param>
         /// <returns></returns>
-        public static Result[] DecodeMultiple(this IBarcodeReaderGeneric reader, MagickImage image)
+        public static Result[] DecodeMultiple(this IBarcodeReaderGeneric reader, IMagickImage image)
         {
             var luminanceSource = new MagickImageLuminanceSource(image);
             return reader.DecodeMultiple(luminanceSource);

--- a/Source/Bindings/ZXing.Magick/BarcodeReader.cs
+++ b/Source/Bindings/ZXing.Magick/BarcodeReader.cs
@@ -22,12 +22,12 @@ namespace ZXing.Magick
     /// <summary>
     /// a barcode reader class which can be used with the Mat type from OpenCVSharp
     /// </summary>
-    public class BarcodeReader : BarcodeReader<MagickImage>
+    public class BarcodeReader : BarcodeReader<IMagickImage>
     {
         /// <summary>
         /// define a custom function for creation of a luminance source with our specialized MagickImage-supporting class
         /// </summary>
-        private static readonly Func<MagickImage, LuminanceSource> defaultCreateLuminanceSource =
+        private static readonly Func<IMagickImage, LuminanceSource> defaultCreateLuminanceSource =
            (image) => new MagickImageLuminanceSource(image);
 
         /// <summary>

--- a/Source/Bindings/ZXing.Magick/BarcodeWriter.Extensions.cs
+++ b/Source/Bindings/ZXing.Magick/BarcodeWriter.Extensions.cs
@@ -29,7 +29,7 @@ namespace ZXing
         /// <param name="writer"></param>
         /// <param name="content"></param>
         /// <returns></returns>
-        public static ImageMagick.MagickImage WriteAsMagickImage(this IBarcodeWriterGeneric writer, string content)
+        public static ImageMagick.IMagickImage WriteAsMagickImage(this IBarcodeWriterGeneric writer, string content)
         {
             var bitmatrix = writer.Encode(content);
             var renderer = new MagickImageRenderer();

--- a/Source/Bindings/ZXing.Magick/BarcodeWriter.cs
+++ b/Source/Bindings/ZXing.Magick/BarcodeWriter.cs
@@ -23,7 +23,7 @@ namespace ZXing.Magick
     /// <summary>
     /// barcode writer which creates ImageSharp Image instances
     /// </summary>
-    public class BarcodeWriter : ZXing.BarcodeWriter<MagickImage>
+    public class BarcodeWriter : ZXing.BarcodeWriter<IMagickImage>
     {
         /// <summary>
         /// contructor

--- a/Source/Bindings/ZXing.Magick/MagickImageLuminanceSource.cs
+++ b/Source/Bindings/ZXing.Magick/MagickImageLuminanceSource.cs
@@ -29,7 +29,7 @@ namespace ZXing.Magick
         /// initializing constructor
         /// </summary>
         /// <param name="image"></param>
-        public MagickImageLuminanceSource(MagickImage image)
+        public MagickImageLuminanceSource(IMagickImage image)
            : base(CalculateLuminance(image), image.Width, image.Height)
         {
         }
@@ -58,7 +58,7 @@ namespace ZXing.Magick
             return new MagickImageLuminanceSource(newLuminances, width, height);
         }
 
-        private static byte[] CalculateLuminance(MagickImage src)
+        private static byte[] CalculateLuminance(IMagickImage src)
         {
             if (src == null)
                 throw new ArgumentNullException(nameof(src));

--- a/Source/Bindings/ZXing.Magick/Renderer/MagickImageRenderer.cs
+++ b/Source/Bindings/ZXing.Magick/Renderer/MagickImageRenderer.cs
@@ -21,14 +21,27 @@ using ImageMagick;
 
 namespace ZXing.Magick.Rendering
 {
-    public class MagickImageRenderer : IBarcodeRenderer<MagickImage>
+    public class MagickImageRenderer : IBarcodeRenderer<IMagickImage>
     {
-        public MagickImage Render(BitMatrix matrix, BarcodeFormat format, string content)
+        private readonly IMagickFactory magickFactory;
+
+        public MagickImageRenderer()
+            : this(null)
+        {
+
+        }
+
+        public MagickImageRenderer(IMagickFactory magickFactory)
+        {
+            this.magickFactory = magickFactory ?? new MagickFactory();
+        }
+
+        public IMagickImage Render(BitMatrix matrix, BarcodeFormat format, string content)
         {
             return Render(matrix, format, content, new EncodingOptions());
         }
 
-        public MagickImage Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
+        public IMagickImage Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
         {
             byte[] header = System.Text.Encoding.UTF8.GetBytes($"P4\n{matrix.Width} {matrix.Height}\n");
 
@@ -66,7 +79,7 @@ namespace ZXing.Magick.Rendering
                 }
             }
 
-            return new MagickImage(totalBuffer);
+            return this.magickFactory.CreateImage(totalBuffer);
         }
     }
 }


### PR DESCRIPTION
I noticed that the ImageMagick binding was coded against a concrete class. Apparently, an abstraction level was added to Magick.NET, so that the same source can be written using `IMagickImage` instead, and a new `IMagickImage` can be created using `IMagickFactory`. This PR is to suggest using these abstractions, if possible.