### PR TITLE
Update to ZXing.ImageSharp to use imagesharp beta0006

### DIFF
--- a/Source/Bindings/ZXing.ImageSharp/Rendering/ImageSharpRenderer.cs
+++ b/Source/Bindings/ZXing.ImageSharp/Rendering/ImageSharpRenderer.cs
@@ -49,7 +49,7 @@ namespace ZXing.ImageSharp.Rendering
         public Image<TPixel> Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
         {
             var width = matrix.Width;
-            var heigth = matrix.Height;
+            var height = matrix.Height;
             var black = new Rgba32(0xFF000000);
             var white = new Rgba32(0xFFFFFFFF);
 
@@ -61,15 +61,15 @@ namespace ZXing.ImageSharp.Rendering
                 {
                     width = options.Width;
                 }
-                if (options.Height > heigth)
+                if (options.Height > height)
                 {
-                    heigth = options.Height;
+                    height = options.Height;
                 }
                 // calculating the scaling factor
                 pixelsize = width / matrix.Width;
-                if (pixelsize > heigth / matrix.Height)
+                if (pixelsize > height / matrix.Height)
                 {
-                    pixelsize = heigth / matrix.Height;
+                    pixelsize = height / matrix.Height;
                 }
             }
 
@@ -86,14 +86,14 @@ namespace ZXing.ImageSharp.Rendering
                         for (var pixelsizeWidth = 0; pixelsizeWidth < pixelsize; pixelsizeWidth++)
                         {
                             var pixel = new TPixel();
-                            pixel.PackFromRgba32(color);
+                            pixel.FromRgba32(color);
                             result[pixelsize * x + pixelsizeWidth, rowOffset] = pixel;
                         }
                     }
                     for (var x = pixelsize * matrix.Width; x < width; x++)
                     {
                         var pixel = new TPixel();
-                        pixel.PackFromRgba32(white);
+                        pixel.FromRgba32(white);
                         result[x, rowOffset] = pixel;
                     }
                 }

--- a/Source/Bindings/ZXing.ImageSharp/ZXing.ImageSharp.csproj
+++ b/Source/Bindings/ZXing.ImageSharp/ZXing.ImageSharp.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <VersionPrefix>0.16.6</VersionPrefix>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <PlatformTarget>anycpu</PlatformTarget>
     <DebugType>portable</DebugType>
@@ -27,14 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0005" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
     <PackageReference Include="ZXing.Net" Version="0.16.4" />
   </ItemGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
This PR fixes issue: [188](https://github.com/micjahn/ZXing.Net/issues/188)

- Changed PackFromRgba32 to FromRgba32
- Removed TargetFramework netstandard1.1: This is no longer supported by ImageSharp