### PR TITLE
Add hint to allow setting desired PDF417 Image Aspect Ratio

### DIFF
--- a/Source/lib/EncodeHintType.cs
+++ b/Source/lib/EncodeHintType.cs
@@ -72,6 +72,12 @@ namespace ZXing
         PDF417_ASPECT_RATIO,
 
         /// <summary>
+        /// Specifies the desired aspect ratio (number of columns / number of rows) of the output image.  Default is 3.
+        /// type: <see cref="System.Single" />.
+        /// </summary>
+        PDF417_IMAGE_ASPECT_RATIO,
+
+        /// <summary>
         /// Specifies whether to use compact mode for PDF417
         /// type: <see cref="System.Boolean" />, or "true" or "false"
         /// <see cref="System.String" /> value

--- a/Source/lib/pdf417/PDF417Writer.cs
+++ b/Source/lib/pdf417/PDF417Writer.cs
@@ -111,6 +111,18 @@ namespace ZXing.PDF417
                         }
                     }
                 }
+                if (hints.ContainsKey(EncodeHintType.PDF417_IMAGE_ASPECT_RATIO) && hints[EncodeHintType.PDF417_IMAGE_ASPECT_RATIO] != null)
+                {
+                    var value = hints[EncodeHintType.PDF417_IMAGE_ASPECT_RATIO];
+                    try
+                    {
+                        encoder.setDesiredAspectRatio(Convert.ToSingle(value));
+                    }
+                    catch
+                    {
+                        // User passed in something that wasn't convertible to single.
+                    }
+                }
                 if (hints.ContainsKey(EncodeHintType.ERROR_CORRECTION) && hints[EncodeHintType.ERROR_CORRECTION] != null)
                 {
                     var value = hints[EncodeHintType.ERROR_CORRECTION];

--- a/Source/lib/pdf417/encoder/PDF417.cs
+++ b/Source/lib/pdf417/encoder/PDF417.cs
@@ -518,7 +518,9 @@ namespace ZXing.PDF417.Internal
                   0x10794, 0x10fb4, 0x10792, 0x10fb2, 0x1c7ea
                }
          };
-        private const float PREFERRED_RATIO = 3.0f;
+
+
+        internal const float DEFAULT_PREFERRED_RATIO = 3.0f;
         private const float DEFAULT_MODULE_WIDTH = 0.357f; //1px in mm
         private const float HEIGHT = 2.0f; //mm
 
@@ -531,6 +533,7 @@ namespace ZXing.PDF417.Internal
         private int maxCols;
         private int maxRows;
         private int minRows;
+        private float preferredRatio = DEFAULT_PREFERRED_RATIO;
 
         internal PDF417()
            : this(false)
@@ -781,7 +784,7 @@ namespace ZXing.PDF417.Internal
                 float newRatio = (((float)BarcodeMatrix.COLUMN_WIDTH * cols + start_stop_width) * DEFAULT_MODULE_WIDTH) / (rows * HEIGHT);
 
                 // ignore if previous ratio is closer to preferred ratio
-                if (dimension != null && Math.Abs(newRatio - PREFERRED_RATIO) > Math.Abs(ratio - PREFERRED_RATIO))
+                if (dimension != null && Math.Abs(newRatio - this.preferredRatio) > Math.Abs(ratio - this.preferredRatio))
                 {
                     continue;
                 }
@@ -806,6 +809,15 @@ namespace ZXing.PDF417.Internal
             }
 
             return dimension;
+        }
+
+        /// <summary>
+        /// Sets the desired aspect ratio for the output image.
+        /// </summary>
+        /// <param name="v"></param>
+        internal void setDesiredAspectRatio(float ratio)
+        {
+            this.preferredRatio = ratio;
         }
 
         /// <summary>

--- a/Source/lib/pdf417/encoder/PDF417EncodingOptions.cs
+++ b/Source/lib/pdf417/encoder/PDF417EncodingOptions.cs
@@ -126,6 +126,26 @@ namespace ZXing.PDF417
         }
 
         /// <summary>
+        /// Specifies what degree of error correction to use
+        /// </summary>
+        public float ImageAspectRatio
+        {
+            get
+            {
+                if (Hints.ContainsKey(EncodeHintType.PDF417_IMAGE_ASPECT_RATIO))
+                {
+                    var value = Hints[EncodeHintType.PDF417_IMAGE_ASPECT_RATIO];
+                    if (value is float)
+                    {
+                        return (float)value;
+                    }
+                }
+                return PDF417.Internal.PDF417.DEFAULT_PREFERRED_RATIO;
+            }
+            set { Hints[EncodeHintType.PDF417_IMAGE_ASPECT_RATIO] = value; }
+        }
+
+        /// <summary>
         /// Specifies what character encoding to use where applicable (type {@link String})
         /// </summary>
         public string CharacterSet


### PR DESCRIPTION
Sometimes you might want a PDF417 barcode with a different aspect ratio. Since the default aspect ratio is hard-coded, there's no way to change the default.

This PR leaves the default the same, but adds the option to change it by adding an encoder hint.

Note that this is my first PR, so if I'm missing something obvious, let me know.