### PR TITLE
Fix null exception when detectorResult.Bits has no value

### DIFF
--- a/Source/lib/datamatrix/DataMatrixReader.cs
+++ b/Source/lib/datamatrix/DataMatrixReader.cs
@@ -63,7 +63,7 @@ namespace ZXing.Datamatrix
             else
             {
                 DetectorResult detectorResult = new Detector(image.BlackMatrix).detect();
-                if (detectorResult == null)
+                if (detectorResult == null || detectorResult.Bits == null)
                     return null;
                 decoderResult = decoder.decode(detectorResult.Bits);
                 points = detectorResult.Points;


### PR DESCRIPTION
This PR fixes an issue in the Datamatrix Reader, when the BitMatrix of the Detector result has no value.