### PR TITLE
Use PixelRowSpan for ImageSharp LuminanceSource

### DIFF
--- a/Source/Bindings/ZXing.ImageSharp/ImageSharpLuminanceSource.cs
+++ b/Source/Bindings/ZXing.ImageSharp/ImageSharpLuminanceSource.cs
@@ -15,6 +15,7 @@
  */
 
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace ZXing.ImageSharp
@@ -52,12 +53,13 @@ namespace ZXing.ImageSharp
 
             for (int y = 0; y < height; y++)
             {
+                var pixelRow = bitmap.GetPixelRowSpan(y);
                 // with alpha channel; some barcodes are completely black if you
                 // only look at the r, g and b channel but the alpha channel controls
                 // the view
                 for (int x = 0; x < width; x++)
                 {
-                    bitmap[x, y].ToRgba32(ref pixelRgba32);
+                    pixelRow[x].ToRgba32(ref pixelRgba32);
                     var luminance = (byte)((BChannelWeight * pixelRgba32.B +
                                              GChannelWeight * pixelRgba32.G +
                                              RChannelWeight * pixelRgba32.R) >> ChannelWeight);

--- a/Source/Bindings/ZXing.ImageSharp/ZXing.ImageSharp.csproj
+++ b/Source/Bindings/ZXing.ImageSharp/ZXing.ImageSharp.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
-    <PackageReference Include="ZXing.Net" Version="0.16.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+    <PackageReference Include="ZXing.Net" Version="0.16.5" />
   </ItemGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">


### PR DESCRIPTION
This PR changes the iteration over the pixels in an image to use the PixelRowSpan, which is faster then the Indexer. In my benchmarks it was 5 times faster to create a LuminaceSource this way.

Here are the benchmark results with the indexer:

|         Method |       Mean |     Error |    StdDev |
|--------------- |-----------:|----------:|----------:|
|  'small image' |   2.975 ms | 0.0113 ms | 0.0100 ms |
| 'medium image' |  15.493 ms | 0.0605 ms | 0.0505 ms |
|    'big image' | 217.680 ms | 0.8688 ms | 0.7702 ms |

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

And here with PIxelRowSpan

|         Method |        Mean |     Error |    StdDev |
|--------------- |------------:|----------:|----------:|
|  'small image' |    543.4 us |   4.80 us |   4.00 us |
| 'medium image' |  2,830.1 us |  10.53 us |   9.85 us |
|    'big image' | 37,512.7 us | 225.53 us | 199.92 us |

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 us   : 1 Microsecond (0.000001 sec)

Where the image sizes are:
- small: 656x380
- medium: 1500x869
- big: 4000x2317