### PR TITLE
Skia - Prevent multiple unnecessary native lib calls

### DIFF
--- a/Source/Bindings/ZXing.SkiaSharp/SKBitmapLuminanceSource.cs
+++ b/Source/Bindings/ZXing.SkiaSharp/SKBitmapLuminanceSource.cs
@@ -65,7 +65,8 @@ namespace ZXing.SkiaSharp
                 throw new ArgumentNullException("src");
 
             var pixels = src.Pixels;
-            for (var index = 0; index < src.Width * src.Height; index++)
+            var length = pixels.Length;
+            for (var index = 0; index < length; index++)
             {
                 var pixel = pixels[index];
                 // Calculate luminance cheaply, favoring green.


### PR DESCRIPTION
Good early morning!  I've been using this library for some years now (Java and .NET port) and have recently gotten into using Skia/SkiaSharp.

After getting a quick project up and running and performing some benchmarks against the GDI+ default implementation, I noticed the Skia binding was lagging behind.

I made an extremely small change after digging into the source of this lib and Skia.Sharp which seems to make a 4-10x performance increase (Depending on the size of the image being scanned).

This is mainly due to a [native call](https://github.com/mono/SkiaSharp/blob/master/binding/Binding/SKBitmap.cs#L339) in the `for` loop when multiplying `src.Width * src.Height`.  Instead, I've changed the conditional to be the length of pixels in the array which should always equal the `src.Width * src.Height`.  

Here's a few benchmarks:


``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.14393.3384 (1607/AnniversaryUpdate/Redstone1)
Intel Xeon CPU E5-2686 v4 2.30GHz, 1 CPU, 4 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (4.7.3468.0), X86 LegacyJIT
  DefaultJob : .NET Framework 4.7.2 (4.7.3468.0), X86 LegacyJIT


```
|      Method |                 File |      Mean |     Error |    StdDev | Rank |
|------------ |--------------------- |----------:|----------:|----------:|-----:|
| SkiaScanner | 2.png [79] | 11.584 ms | 0.1313 ms | 0.1164 ms |    2 |
|   Optimized | 2.png [79] |  1.294 ms | 0.0121 ms | 0.0107 ms |    1 |


``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.14393.3384 (1607/AnniversaryUpdate/Redstone1)
Intel Xeon CPU E5-2686 v4 2.30GHz, 1 CPU, 4 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (4.7.3468.0), X86 LegacyJIT
  DefaultJob : .NET Framework 4.7.2 (4.7.3468.0), X86 LegacyJIT


```
|      Method |                 File |     Mean |    Error |   StdDev | Rank |
|------------ |--------------------- |---------:|---------:|---------:|-----:|
| SkiaScanner | 5.png [80] | 57.08 ms | 0.102 ms | 0.095 ms |    2 |
|   Optimized | 5.png [80] | 12.09 ms | 0.033 ms | 0.030 ms |    1 |