### PR TITLE
Magick.NET-Q8-AnyCPU Package update

### DIFF
--- a/Source/Bindings/ZXing.Magick/BarcodeWriter.Extensions.cs
+++ b/Source/Bindings/ZXing.Magick/BarcodeWriter.Extensions.cs
@@ -29,7 +29,7 @@ namespace ZXing
         /// <param name="writer"></param>
         /// <param name="content"></param>
         /// <returns></returns>
-        public static ImageMagick.IMagickImage WriteAsMagickImage(this IBarcodeWriterGeneric writer, string content)
+        public static ImageMagick.IMagickImage<byte> WriteAsMagickImage(this IBarcodeWriterGeneric writer, string content)
         {
             var bitmatrix = writer.Encode(content);
             var renderer = new MagickImageRenderer();

--- a/Source/Bindings/ZXing.Magick/BarcodeWriter.cs
+++ b/Source/Bindings/ZXing.Magick/BarcodeWriter.cs
@@ -23,7 +23,7 @@ namespace ZXing.Magick
     /// <summary>
     /// barcode writer which creates ImageSharp Image instances
     /// </summary>
-    public class BarcodeWriter : ZXing.BarcodeWriter<IMagickImage>
+    public class BarcodeWriter : ZXing.BarcodeWriter<IMagickImage<byte>>
     {
         /// <summary>
         /// contructor

--- a/Source/Bindings/ZXing.Magick/Renderer/MagickImageRenderer.cs
+++ b/Source/Bindings/ZXing.Magick/Renderer/MagickImageRenderer.cs
@@ -24,7 +24,7 @@ namespace ZXing.Magick.Rendering
     /// <summary>
     /// renderer class which generates a IMagickImage from a BitMatrix
     /// </summary>
-    public class MagickImageRenderer : IBarcodeRenderer<IMagickImage>
+    public class MagickImageRenderer : IBarcodeRenderer<IMagickImage<byte>>
     {
         private readonly MagickFactory magickFactory;
 
@@ -55,7 +55,7 @@ namespace ZXing.Magick.Rendering
         /// <param name="format"></param>
         /// <param name="content"></param>
         /// <returns></returns>
-        public IMagickImage Render(BitMatrix matrix, BarcodeFormat format, string content)
+        public IMagickImage<byte> Render(BitMatrix matrix, BarcodeFormat format, string content)
         {
             return Render(matrix, format, content, new EncodingOptions());
         }
@@ -68,7 +68,7 @@ namespace ZXing.Magick.Rendering
         /// <param name="content"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public IMagickImage Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
+        public IMagickImage<byte> Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
         {
             byte[] header = System.Text.Encoding.UTF8.GetBytes($"P4\n{matrix.Width} {matrix.Height}\n");
 

--- a/Source/Bindings/ZXing.Magick/ZXing.Magick.csproj
+++ b/Source/Bindings/ZXing.Magick/ZXing.Magick.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.19.0.1" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.21.1" />
     <PackageReference Include="ZXing.Net" Version="0.16.5" />
   </ItemGroup>
 

--- a/Source/Bindings/ZXing.Magick/project.nuspec
+++ b/Source/Bindings/ZXing.Magick/project.nuspec
@@ -17,20 +17,20 @@
 		<dependencies>
 			<group targetFramework="net20">
 				<dependency id="ZXing.Net" version="0.16.5.0" exclude="Build,Analyzers" />
-				<dependency id="Magick.NET-Q8-AnyCPU" version="7.19.0.1" exclude="Build,Analyzers" />
+				<dependency id="Magick.NET-Q8-AnyCPU" version="7.21.1" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework="net40">
 				<dependency id="ZXing.Net" version="0.16.5.0" exclude="Build,Analyzers" />
-				<dependency id="Magick.NET-Q8-AnyCPU" version="7.19.0.1" exclude="Build,Analyzers" />
+				<dependency id="Magick.NET-Q8-AnyCPU" version="7.21.1" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework="netstandard1.3">
 				<dependency id="ZXing.Net" version="0.16.5.0" exclude="Build,Analyzers" />
-				<dependency id="Magick.NET-Q8-AnyCPU" version="7.19.0.1" exclude="Build,Analyzers" />
+				<dependency id="Magick.NET-Q8-AnyCPU" version="7.21.1" exclude="Build,Analyzers" />
 				<dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework="netstandard2.0">
 				<dependency id="ZXing.Net" version="0.16.5.0" exclude="Build,Analyzers" />
-				<dependency id="Magick.NET-Q8-AnyCPU" version="7.19.0.1" exclude="Build,Analyzers" />
+				<dependency id="Magick.NET-Q8-AnyCPU" version="7.21.1" exclude="Build,Analyzers" />
 				<dependency id="NETStandard.Library" version="2.0.0" exclude="Build,Analyzers" />
 			</group>
 		</dependencies>


### PR DESCRIPTION
updated Nuget Package "Magick.NET-Q8-AnyCPU" from 7.19.0.1 to 7.21.1
made changes in the ZXing.Magick project to return IMagickImage<byte> instead of the generic IMagickImage.