### PR TITLE
fix: SVGRenderer CSS rgba function was supplied with incorrect values

### DIFF
--- a/Source/lib/renderer/SVGRenderer.cs
+++ b/Source/lib/renderer/SVGRenderer.cs
@@ -463,7 +463,7 @@ namespace ZXing.Rendering
             internal static string GetBackgroundStyle(Color color)
             {
                 double alpha = ConvertAlpha(color);
-                return string.Format("style=\"background-color:rgb({0},{1},{2});background-color:rgba({3});\"",
+                return string.Format("style=\"background-color:rgb({0},{1},{2});background-color:rgba({0}, {1}, {2}, {3});\"",
                     color.R, color.G, color.B, alpha);
             }
 


### PR DESCRIPTION
There was an issue with `SVGRenderer`. Specifically, it created an SVG with incorrect values for the `rgba` css function. Fixed that.

Previously, only alpha was supplied in the style. Now I'm passing RGBA values as we're supposed to.

I'm not sure why `background-color` is set twice there actually. But I haven't touched the first part in case it's necessary. 