### PR TITLE
Use Magick.NET.Core instead.

### DIFF
--- a/Source/Bindings/ZXing.Magick/BarcodeWriter.Extensions.cs
+++ b/Source/Bindings/ZXing.Magick/BarcodeWriter.Extensions.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using ImageMagick;
 using ZXing.Magick.Rendering;
 
 namespace ZXing
@@ -24,15 +25,17 @@ namespace ZXing
     public static class BarcodeWriterExtensions
     {
         /// <summary>
-        /// uses the BarcodeWriterGeneric implementation and the <see cref="MagickImageRenderer"/> class for decoding
+        /// uses the BarcodeWriterGeneric implementation and the <see cref="MagickImageRenderer{TQuantumType}"/> class for decoding
         /// </summary>
         /// <param name="writer"></param>
+        /// <param name="magickImageFactory"></param>
         /// <param name="content"></param>
         /// <returns></returns>
-        public static ImageMagick.IMagickImage<byte> WriteAsMagickImage(this IBarcodeWriterGeneric writer, string content)
+        public static IMagickImage<TQuantumType> WriteAsMagickImage<TQuantumType>(this IBarcodeWriterGeneric writer, IMagickImageFactory<TQuantumType> magickImageFactory, string content)
+            where TQuantumType : struct
         {
             var bitmatrix = writer.Encode(content);
-            var renderer = new MagickImageRenderer();
+            var renderer = new MagickImageRenderer<TQuantumType>(magickImageFactory);
             return renderer.Render(bitmatrix, writer.Format, content, writer.Options);
         }
     }

--- a/Source/Bindings/ZXing.Magick/BarcodeWriter.cs
+++ b/Source/Bindings/ZXing.Magick/BarcodeWriter.cs
@@ -21,16 +21,17 @@ using ZXing.Magick.Rendering;
 namespace ZXing.Magick
 {
     /// <summary>
-    /// barcode writer which creates ImageSharp Image instances
+    /// barcode writer which creates Magick.NET Image instances
     /// </summary>
-    public class BarcodeWriter : ZXing.BarcodeWriter<IMagickImage<byte>>
+    public class BarcodeWriter<TQuantumType> : ZXing.BarcodeWriter<IMagickImage<TQuantumType>>
+        where TQuantumType : struct
     {
         /// <summary>
         /// contructor
         /// </summary>
-        public BarcodeWriter()
+        public BarcodeWriter(IMagickImageFactory<TQuantumType> imageFactory)
         {
-            Renderer = new MagickImageRenderer();
+            Renderer = new MagickImageRenderer<TQuantumType>(imageFactory);
         }
     }
 }

--- a/Source/Bindings/ZXing.Magick/Renderer/MagickImageRenderer.cs
+++ b/Source/Bindings/ZXing.Magick/Renderer/MagickImageRenderer.cs
@@ -22,53 +22,43 @@ using ImageMagick;
 namespace ZXing.Magick.Rendering
 {
     /// <summary>
-    /// renderer class which generates a IMagickImage from a BitMatrix
+    /// renderer class which generates a <see cref="IMagickImage{TQuantumType}"/> from a BitMatrix
     /// </summary>
-    public class MagickImageRenderer : IBarcodeRenderer<IMagickImage<byte>>
+    public class MagickImageRenderer<TQuantumType> : IBarcodeRenderer<IMagickImage<TQuantumType>>
+        where TQuantumType : struct
     {
-        private readonly MagickFactory magickFactory;
+        private readonly IMagickImageFactory<TQuantumType> magickImageFactory;
 
         /// <summary>
-        /// default constructor
+        /// constructor, which can be used with a special implementation of <see cref="IMagickImageFactory{TQuantumType}"/>.
         /// </summary>
-        public MagickImageRenderer()
-            : this(null)
+        /// <param name="magickImageFactory"></param>
+        public MagickImageRenderer(IMagickImageFactory<TQuantumType> magickImageFactory)
         {
-
+            this.magickImageFactory = magickImageFactory;
         }
 
         /// <summary>
-        /// constructor, which can be used if a special implementation of IMagickFactory is need.
-        /// TODO: at the moment the instance of magickFactory has to be a subtype of MagickFactory because ImagickFactory doesn't provide the property Image
-        /// </summary>
-        /// <param name="magickFactory"></param>
-        public MagickImageRenderer(IMagickFactory magickFactory)
-        {
-            // TODO: current version of Magick doesn't have all necessary properties defined for IMagickFactory
-            this.magickFactory = magickFactory as MagickFactory ?? new MagickFactory();
-        }
-
-        /// <summary>
-        /// renders the BitMatrix as MagickImage
+        /// renders the BitMatrix as <see cref="IMagickImage{TQuantumType}"/>
         /// </summary>
         /// <param name="matrix"></param>
         /// <param name="format"></param>
         /// <param name="content"></param>
         /// <returns></returns>
-        public IMagickImage<byte> Render(BitMatrix matrix, BarcodeFormat format, string content)
+        public IMagickImage<TQuantumType> Render(BitMatrix matrix, BarcodeFormat format, string content)
         {
             return Render(matrix, format, content, new EncodingOptions());
         }
 
         /// <summary>
-        /// renders the BitMatrix as MagickImage
+        /// renders the BitMatrix as <see cref="IMagickImage{TQuantumType}"/>
         /// </summary>
         /// <param name="matrix"></param>
         /// <param name="format"></param>
         /// <param name="content"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public IMagickImage<byte> Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
+        public IMagickImage<TQuantumType> Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
         {
             byte[] header = System.Text.Encoding.UTF8.GetBytes($"P4\n{matrix.Width} {matrix.Height}\n");
 
@@ -106,7 +96,7 @@ namespace ZXing.Magick.Rendering
                 }
             }
 
-            return this.magickFactory.Image.Create(totalBuffer);
+            return this.magickImageFactory.Create(totalBuffer);
         }
     }
 }

--- a/Source/Bindings/ZXing.Magick/ZXing.Magick.csproj
+++ b/Source/Bindings/ZXing.Magick/ZXing.Magick.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.16.9</VersionPrefix>
-    <TargetFrameworks>net20;net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>anycpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -34,23 +34,12 @@
     <Reference Include="System" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net20' ">
     <DefineConstants>$(DefineConstants);NET20</DefineConstants>
     <DebugType>full</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <DefineConstants>$(DefineConstants);NET40</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-    <DebugType>portable</DebugType>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 

--- a/Source/Bindings/ZXing.Magick/ZXing.Magick.csproj
+++ b/Source/Bindings/ZXing.Magick/ZXing.Magick.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.22.3" />
+    <PackageReference Include="Magick.NET.Core" Version="11.2.0" />
     <PackageReference Include="ZXing.Net" Version="0.16.7" />
   </ItemGroup>
 
@@ -46,12 +46,6 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <DefineConstants>$(DefineConstants);NET40</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-    <DebugType>portable</DebugType>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/Source/Bindings/ZXing.Magick/ZXing.Magick.csproj
+++ b/Source/Bindings/ZXing.Magick/ZXing.Magick.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.16.9</VersionPrefix>
-    <TargetFrameworks>net20;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net40;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>anycpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -12,7 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-	<EnableDefaultCompileItems>False</EnableDefaultCompileItems>
+    <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Bindings/ZXing.Magick/project.nuspec
+++ b/Source/Bindings/ZXing.Magick/project.nuspec
@@ -20,14 +20,14 @@
 				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
 				<dependency id="Magick.NET.Core" Version="11.2.0" exclude="Build,Analyzers" />
 			</group>
-			<group targetFramework="net40">
-				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
-				<dependency id="Magick.NET.Core" Version="11.2.0" exclude="Build,Analyzers" />
-			</group>
 			<group targetFramework="netstandard2.0">
 				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
 				<dependency id="Magick.NET.Core" Version="11.2.0" exclude="Build,Analyzers" />
 				<dependency id="NETStandard.Library" version="2.0.0" exclude="Build,Analyzers" />
+			</group>
+			<group targetFramework="netstandard2.1">
+				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
+				<dependency id="Magick.NET.Core" Version="11.2.0" exclude="Build,Analyzers" />
 			</group>
 		</dependencies>
 	</metadata>
@@ -36,11 +36,11 @@
 		<file src="bin\Release\net20\ZXing.Magick.dll" target="lib\net20\ZXing.Magick.dll" />
 		<file src="bin\Release\net20\ZXing.Magick.pdb" target="lib\net20\ZXing.Magick.pdb" />
 		<file src="bin\Release\net20\ZXing.Magick.xml" target="lib\net20\ZXing.Magick.xml" />
-		<file src="bin\Release\net40\ZXing.Magick.dll" target="lib\net40\ZXing.Magick.dll" />
-		<file src="bin\Release\net40\ZXing.Magick.pdb" target="lib\net40\ZXing.Magick.pdb" />
-		<file src="bin\Release\net40\ZXing.Magick.xml" target="lib\net40\ZXing.Magick.xml" />
 		<file src="bin\Release\netstandard2.0\ZXing.Magick.dll" target="lib\netstandard2.0\ZXing.Magick.dll" />
 		<file src="bin\Release\netstandard2.0\ZXing.Magick.pdb" target="lib\netstandard2.0\ZXing.Magick.pdb" />
 		<file src="bin\Release\netstandard2.0\ZXing.Magick.xml" target="lib\netstandard2.0\ZXing.Magick.xml" />
+		<file src="bin\Release\netstandard2.1\ZXing.Magick.dll" target="lib\netstandard2.0\ZXing.Magick.dll" />
+		<file src="bin\Release\netstandard2.1\ZXing.Magick.pdb" target="lib\netstandard2.0\ZXing.Magick.pdb" />
+		<file src="bin\Release\netstandard2.1\ZXing.Magick.xml" target="lib\netstandard2.0\ZXing.Magick.xml" />
 	</files>
 </package>

--- a/Source/Bindings/ZXing.Magick/project.nuspec
+++ b/Source/Bindings/ZXing.Magick/project.nuspec
@@ -18,15 +18,15 @@
 		<dependencies>
 			<group targetFramework="net20">
 				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
-				<dependency id="Magick.NET-Q8-AnyCPU" version="7.22.3" exclude="Build,Analyzers" />
+				<dependency id="Magick.NET.Core" Version="11.2.0" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework="net40">
 				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
-				<dependency id="Magick.NET-Q8-AnyCPU" version="7.22.3" exclude="Build,Analyzers" />
+				<dependency id="Magick.NET.Core" Version="11.2.0" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework="netstandard2.0">
 				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
-				<dependency id="Magick.NET-Q8-AnyCPU" version="7.22.3" exclude="Build,Analyzers" />
+				<dependency id="Magick.NET.Core" Version="11.2.0" exclude="Build,Analyzers" />
 				<dependency id="NETStandard.Library" version="2.0.0" exclude="Build,Analyzers" />
 			</group>
 		</dependencies>
@@ -39,9 +39,6 @@
 		<file src="bin\Release\net40\ZXing.Magick.dll" target="lib\net40\ZXing.Magick.dll" />
 		<file src="bin\Release\net40\ZXing.Magick.pdb" target="lib\net40\ZXing.Magick.pdb" />
 		<file src="bin\Release\net40\ZXing.Magick.xml" target="lib\net40\ZXing.Magick.xml" />
-		<file src="bin\Release\netstandard1.3\ZXing.Magick.dll" target="lib\netstandard1.3\ZXing.Magick.dll" />
-		<file src="bin\Release\netstandard1.3\ZXing.Magick.pdb" target="lib\netstandard1.3\ZXing.Magick.pdb" />
-		<file src="bin\Release\netstandard1.3\ZXing.Magick.xml" target="lib\netstandard1.3\ZXing.Magick.xml" />
 		<file src="bin\Release\netstandard2.0\ZXing.Magick.dll" target="lib\netstandard2.0\ZXing.Magick.dll" />
 		<file src="bin\Release\netstandard2.0\ZXing.Magick.pdb" target="lib\netstandard2.0\ZXing.Magick.pdb" />
 		<file src="bin\Release\netstandard2.0\ZXing.Magick.xml" target="lib\netstandard2.0\ZXing.Magick.xml" />

--- a/Source/Bindings/ZXing.Magick/project.nuspec
+++ b/Source/Bindings/ZXing.Magick/project.nuspec
@@ -24,11 +24,6 @@
 				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
 				<dependency id="Magick.NET-Q8-AnyCPU" version="7.22.3" exclude="Build,Analyzers" />
 			</group>
-			<group targetFramework="netstandard1.3">
-				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
-				<dependency id="Magick.NET-Q8-AnyCPU" version="7.22.3" exclude="Build,Analyzers" />
-				<dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
-			</group>
 			<group targetFramework="netstandard2.0">
 				<dependency id="ZXing.Net" version="0.16.7.0" exclude="Build,Analyzers" />
 				<dependency id="Magick.NET-Q8-AnyCPU" version="7.22.3" exclude="Build,Analyzers" />


### PR DESCRIPTION
This PR switches to use the Magick.NET.Core library instead of the Magick.NET-Q8-AnyCPU library. This makes it possible to use this library in combination with all the Magick.NET-* libraries. This did require a signature change in the `WriteAsMagickImage` method to make it possible to support this. When making this changes I also upgraded to the most recent version of Magick.NET.Core.