### PR TITLE
Specify the result of decoding (QR, Datamatrix, AZTEC and MaxiCode) as byte[]

### DIFF
--- a/Source/lib/Result.cs
+++ b/Source/lib/Result.cs
@@ -109,6 +109,26 @@ namespace ZXing
         /// <summary>
         /// Initializes a new instance of the <see cref="Result"/> class.
         /// </summary>
+        /// <param name="text"></param>
+        /// <param name="data"></param>
+        /// <param name="rawBytes"></param>
+        /// <param name="numBits"></param>
+        /// <param name="resultPoints"></param>
+        /// <param name="format"></param>
+        public Result(String text,
+                      byte[] data,
+                      byte[] rawBytes,
+                      int numBits,
+                      ResultPoint[] resultPoints,
+                      BarcodeFormat format)
+            : this(text,rawBytes, numBits, resultPoints, format)
+        {
+            this.Data = data;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Result"/> class.
+        /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="rawBytes">The raw bytes.</param>
         /// <param name="resultPoints">The result points.</param>

--- a/Source/lib/Result.cs
+++ b/Source/lib/Result.cs
@@ -27,6 +27,9 @@ namespace ZXing
         /// <returns>raw text encoded by the barcode, if applicable, otherwise <code>null</code></returns>
         public String Text { get; private set; }
 
+        /// <returns>raw text binary representation, if applicable, otherwise <code>null</code></returns>
+        public byte[] Data { get; private set; }
+
         /// <returns>raw bytes encoded by the barcode, if applicable, otherwise <code>null</code></returns>
         public byte[] RawBytes { get; private set; }
 
@@ -73,6 +76,20 @@ namespace ZXing
         }
 
         /// <summary>
+        /// Initizalizes a new instance of the <see cref="Result"/> class.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="data"></param>
+        /// <param name="rawBytes"></param>
+        /// <param name="resultPoints"></param>
+        /// <param name="format"></param>
+        public Result(String text, byte[] data, byte[] rawBytes, ResultPoint[] resultPoints, BarcodeFormat format)
+            : this(text, rawBytes, resultPoints, format)
+        {
+            Data = data;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Result"/> class.
         /// </summary>
         /// <param name="text">The text.</param>
@@ -112,12 +129,18 @@ namespace ZXing
         /// <param name="format">The format.</param>
         /// <param name="timestamp">The timestamp.</param>
         public Result(String text, byte[] rawBytes, int numBits, ResultPoint[] resultPoints, BarcodeFormat format, long timestamp)
+            : this(text, null, rawBytes, numBits, resultPoints, format, timestamp)
+        {
+        }
+
+        public Result(String text, byte[] data, byte[] rawBytes, int numBits, ResultPoint[] resultPoints, BarcodeFormat format, long timestamp)
         {
             if (text == null && rawBytes == null)
             {
                 throw new ArgumentException("Text and bytes are null");
             }
             Text = text;
+            Data = data;
             RawBytes = rawBytes;
             NumBits = numBits;
             ResultPoints = resultPoints;

--- a/Source/lib/aztec/AztecReader.cs
+++ b/Source/lib/aztec/AztecReader.cs
@@ -92,7 +92,7 @@ namespace ZXing.Aztec
                 }
             }
 
-            var result = new Result(decoderResult.Text, decoderResult.RawBytes, decoderResult.NumBits, points, BarcodeFormat.AZTEC);
+            var result = new Result(decoderResult.Text, decoderResult.Data, decoderResult.RawBytes, decoderResult.NumBits, points, BarcodeFormat.AZTEC);
 
             IList<byte[]> byteSegments = decoderResult.ByteSegments;
             if (byteSegments != null)

--- a/Source/lib/common/DecoderResult.cs
+++ b/Source/lib/common/DecoderResult.cs
@@ -43,6 +43,11 @@ namespace ZXing.Common
         public String Text { get; private set; }
 
         /// <summary>
+        /// bytes representing the encoded text field
+        /// </summary>
+        public byte[] Data { get; private set; }
+
+        /// <summary>
         /// list of byte segments in the result, or null if not applicable
         /// </summary>
         public IList<byte[]> ByteSegments { get; private set; }
@@ -105,6 +110,20 @@ namespace ZXing.Common
         }
 
         /// <summary>
+        /// initilizing constructor 
+        /// </summary>
+        /// <param name="rawBytes"></param>
+        /// <param name="data"></param>
+        /// <param name="text"></param>
+        /// <param name="byteSegments"></param>
+        /// <param name="ecLevel"></param>
+        public DecoderResult(byte[] rawBytes, byte[] data, String text, List<byte[]> byteSegments, String ecLevel)
+            : this(rawBytes, text, byteSegments, ecLevel)
+        {
+            Data = data;
+        }
+
+        /// <summary>
         /// initializing constructor
         /// </summary>
         /// <param name="rawBytes"></param>
@@ -116,6 +135,22 @@ namespace ZXing.Common
            : this(rawBytes, text, byteSegments, ecLevel, -1, -1, symbologyModifier)
         {
         }
+
+        /// <summary>
+        /// initializing constructor
+        /// </summary>
+        /// <param name="rawBytes"></param>
+        /// <param name="data"></param>
+        /// <param name="text"></param>
+        /// <param name="byteSegments"></param>
+        /// <param name="ecLevel"></param>
+        /// <param name="symbologyModifier"></param>
+        public DecoderResult(byte[] rawBytes, byte[] data, String text, IList<byte[]> byteSegments, String ecLevel, int symbologyModifier)
+           : this(rawBytes, text, byteSegments, ecLevel, -1, -1, symbologyModifier)
+        {
+            this.Data = data;
+        }
+
         /// <summary>
         /// initializing constructor
         /// </summary>
@@ -155,6 +190,23 @@ namespace ZXing.Common
         /// initializing constructor
         /// </summary>
         /// <param name="rawBytes"></param>
+        /// <param name="data"></param>
+        /// <param name="text"></param>
+        /// <param name="byteSegments"></param>
+        /// <param name="ecLevel"></param>
+        /// <param name="saSequence"></param>
+        /// <param name="saParity"></param>
+        /// <param name="symbologyModifier"></param>
+        public DecoderResult(byte[] rawBytes, byte[] data, String text, IList<byte[]> byteSegments, String ecLevel, int saSequence, int saParity, int symbologyModifier)
+            : this(rawBytes, text, byteSegments, ecLevel, saSequence, saParity, symbologyModifier)
+        {
+            Data = data;
+        }
+
+        /// <summary>
+        /// initializing constructor
+        /// </summary>
+        /// <param name="rawBytes"></param>
         /// <param name="numBits"></param>
         /// <param name="text"></param>
         /// <param name="byteSegments"></param>
@@ -176,12 +228,29 @@ namespace ZXing.Common
         /// <param name="saParity"></param>
         /// <param name="symbologyModifier"></param>
         public DecoderResult(byte[] rawBytes, int numBits, String text, IList<byte[]> byteSegments, String ecLevel, int saSequence, int saParity, int symbologyModifier)
+            : this(rawBytes, null, numBits, text, byteSegments, ecLevel, saSequence, saParity, symbologyModifier)
+        {
+        }
+
+        /// <summary>
+        /// initializing constructor
+        /// </summary>
+        /// <param name="rawBytes"></param>
+        /// <param name="numBits"></param>
+        /// <param name="text"></param>
+        /// <param name="byteSegments"></param>
+        /// <param name="ecLevel"></param>
+        /// <param name="saSequence"></param>
+        /// <param name="saParity"></param>
+        /// <param name="symbologyModifier"></param>
+        public DecoderResult(byte[] rawBytes, byte[] data, int numBits, String text, IList<byte[]> byteSegments, String ecLevel, int saSequence, int saParity, int symbologyModifier)
         {
             if (rawBytes == null && text == null)
             {
                 throw new ArgumentException();
             }
             RawBytes = rawBytes;
+            Data = data;
             NumBits = numBits;
             Text = text;
             ByteSegments = byteSegments;

--- a/Source/lib/common/DecoderResult.cs
+++ b/Source/lib/common/DecoderResult.cs
@@ -106,7 +106,7 @@ namespace ZXing.Common
         public DecoderResult(byte[] rawBytes, String text, List<byte[]> byteSegments, String ecLevel)
             : this(rawBytes, text, byteSegments, ecLevel, -1, -1, 0)
         {
-            
+
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace ZXing.Common
                      int saParity)
              : this(rawBytes, text, byteSegments, ecLevel, saSequence, saParity, 0)
         {
-            
+
         }
 
         /// <summary>
@@ -215,6 +215,22 @@ namespace ZXing.Common
            : this(rawBytes, numBits, text, byteSegments, ecLevel, -1, -1, 0)
         {
         }
+
+        /// <summary>
+        /// initializing constructor
+        /// </summary>
+        /// <param name="rawBytes"></param>
+        /// <param name="numBits"></param>
+        /// <param name="data"></param>
+        /// <param name="text"></param>
+        /// <param name="byteSegments"></param>
+        /// <param name="ecLevel"></param>
+        public DecoderResult(byte[] rawBytes, int numBits, byte[] data, String text, IList<byte[]> byteSegments, String ecLevel)
+            : this(rawBytes, numBits, text, byteSegments, ecLevel)
+        {
+            this.Data = data;
+        }
+
 
         /// <summary>
         /// initializing constructor

--- a/Source/lib/datamatrix/DataMatrixReader.cs
+++ b/Source/lib/datamatrix/DataMatrixReader.cs
@@ -71,7 +71,7 @@ namespace ZXing.Datamatrix
             if (decoderResult == null)
                 return null;
 
-            Result result = new Result(decoderResult.Text, decoderResult.RawBytes, points,
+            Result result = new Result(decoderResult.Text, decoderResult.Data, decoderResult.RawBytes, points,
                 BarcodeFormat.DATA_MATRIX);
             IList<byte[]> byteSegments = decoderResult.ByteSegments;
             if (byteSegments != null)

--- a/Source/lib/datamatrix/decoder/DecodedBitStreamParser.cs
+++ b/Source/lib/datamatrix/decoder/DecodedBitStreamParser.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using ZXing.Common;
 
@@ -86,7 +87,7 @@ namespace ZXing.Datamatrix.Internal
         {
             BitSource bits = new BitSource(bytes);
             ECIStringBuilder result = new ECIStringBuilder(100);
-            byte[] encodedResult = new byte[100];
+            MemoryStream encodedResult = new MemoryStream();
             StringBuilder resultTrailer = new StringBuilder(0);
             List<byte[]> byteSegments = new List<byte[]>(1);
             Mode mode = Mode.ASCII_ENCODE;
@@ -97,7 +98,7 @@ namespace ZXing.Datamatrix.Internal
             {
                 if (mode == Mode.ASCII_ENCODE)
                 {
-                    if (!decodeAsciiSegment(bits, result, resultTrailer, fnc1Positions, out mode))
+                    if (!decodeAsciiSegment(bits, encodedResult, result, resultTrailer, fnc1Positions, out mode))
                         return null;
                 }
                 else
@@ -105,23 +106,23 @@ namespace ZXing.Datamatrix.Internal
                     switch (mode)
                     {
                         case Mode.C40_ENCODE:
-                            if (!decodeC40Segment(bits, result, fnc1Positions))
+                            if (!decodeC40Segment(bits, encodedResult, result, fnc1Positions))
                                 return null;
                             break;
                         case Mode.TEXT_ENCODE:
-                            if (!decodeTextSegment(bits, result, fnc1Positions))
+                            if (!decodeTextSegment(bits, encodedResult, result, fnc1Positions))
                                 return null;
                             break;
                         case Mode.ANSIX12_ENCODE:
-                            if (!decodeAnsiX12Segment(bits, result))
+                            if (!decodeAnsiX12Segment(bits, encodedResult, result))
                                 return null;
                             break;
                         case Mode.EDIFACT_ENCODE:
-                            if (!decodeEdifactSegment(bits, result))
+                            if (!decodeEdifactSegment(bits, encodedResult, result))
                                 return null;
                             break;
                         case Mode.BASE256_ENCODE:
-                            if (!decodeBase256Segment(bits, out encodedResult, result, byteSegments))
+                            if (!decodeBase256Segment(bits, encodedResult, result, byteSegments))
                                 return null;
                             break;
                         case Mode.ECI_ENCODE:
@@ -137,6 +138,8 @@ namespace ZXing.Datamatrix.Internal
             if (resultTrailer.Length > 0)
             {
                 result.Append(resultTrailer.ToString());
+                var resultTrailerBytes = Encoding.UTF8.GetBytes(resultTrailer.ToString());
+                encodedResult.Write(resultTrailerBytes, 0, resultTrailerBytes.Length);
             }
             if (isECIencoded)
             {
@@ -170,13 +173,14 @@ namespace ZXing.Datamatrix.Internal
                     symbologyModifier = 1;
                 }
             }
-            return new DecoderResult(bytes, encodedResult, result.ToString(), byteSegments.Count == 0 ? null : byteSegments, null, symbologyModifier);
+            return new DecoderResult(bytes, encodedResult.ToArray(), result.ToString(), byteSegments.Count == 0 ? null : byteSegments, null, symbologyModifier);
         }
 
         /// <summary>
         /// See ISO 16022:2006, 5.2.3 and Annex C, Table C.2
         /// </summary>
         private static bool decodeAsciiSegment(BitSource bits,
+                                               MemoryStream encodedResult,
                                                ECIStringBuilder result,
                                                StringBuilder resultTrailer,
                                                List<int> fnc1positions,
@@ -199,6 +203,7 @@ namespace ZXing.Datamatrix.Internal
                         oneByte += 128;
                         //upperShift = false;
                     }
+                    encodedResult.WriteByte((byte) (oneByte - 1));
                     result.Append((char)(oneByte - 1));
                     mode = Mode.ASCII_ENCODE;
                     return true;
@@ -216,8 +221,10 @@ namespace ZXing.Datamatrix.Internal
                     if (value < 10)
                     {
                         // pad with '0' for single digit values
+                        encodedResult.WriteByte((byte)48); // ASCII representation of byte 48 is the caracter '0'
                         result.Append('0');
                     }
+                    encodedResult.WriteByte((byte)value);
                     result.Append(value);
                 }
                 else
@@ -233,6 +240,7 @@ namespace ZXing.Datamatrix.Internal
                         case 232: // FNC1
                             fnc1positions.Add(result.Length);
                             result.Append((char)29); // translate as ASCII 29
+                            encodedResult.WriteByte((byte)29);
                             break;
                         case 233: // Structured Append
                         case 234: // Reader Programming
@@ -244,10 +252,14 @@ namespace ZXing.Datamatrix.Internal
                             break;
                         case 236: // 05 Macro
                             result.Append("[)>\u001E05\u001D");
+                            byte[] macro05 = Encoding.UTF8.GetBytes("[)>\u001E05\u001D");
+                            encodedResult.Write(macro05, 0, macro05.Length);
                             resultTrailer.Insert(0, "\u001E\u0004");
                             break;
                         case 237: // 06 Macro
                             result.Append("[)>\u001E06\u001D");
+                            byte[] macro06 = Encoding.UTF8.GetBytes("[)>\u001E06\u001D");
+                            encodedResult.Write(macro06, 0, macro06.Length);
                             resultTrailer.Insert(0, "\u001E\u0004");
                             break;
                         case 238: // Latch to ANSI X12 encodation
@@ -280,7 +292,7 @@ namespace ZXing.Datamatrix.Internal
         /// <summary>
         /// See ISO 16022:2006, 5.2.5 and Annex C, Table C.1
         /// </summary>
-        private static bool decodeC40Segment(BitSource bits, ECIStringBuilder result, List<int> fnc1positions)
+        private static bool decodeC40Segment(BitSource bits, MemoryStream encodedResult, ECIStringBuilder result, List<int> fnc1positions)
         {
             // Three C40 values are encoded in a 16-bit value as
             // (1600 * C1) + (40 * C2) + C3 + 1
@@ -322,11 +334,13 @@ namespace ZXing.Datamatrix.Internal
                                 if (upperShift)
                                 {
                                     result.Append((char)(c40char + 128));
+                                    encodedResult.WriteByte((byte)(c40char + 128));
                                     upperShift = false;
                                 }
                                 else
                                 {
                                     result.Append(c40char);
+                                    encodedResult.WriteByte((byte)c40char);
                                 }
                             }
                             else
@@ -338,11 +352,13 @@ namespace ZXing.Datamatrix.Internal
                             if (upperShift)
                             {
                                 result.Append((char)(cValue + 128));
+                                encodedResult.WriteByte((byte)(cValue + 128));
                                 upperShift = false;
                             }
                             else
                             {
                                 result.Append((char)cValue);
+                                encodedResult.WriteByte((byte)cValue);
                             }
                             shift = 0;
                             break;
@@ -353,11 +369,13 @@ namespace ZXing.Datamatrix.Internal
                                 if (upperShift)
                                 {
                                     result.Append((char)(c40char + 128));
+                                    encodedResult.WriteByte((byte)(c40char + 128));
                                     upperShift = false;
                                 }
                                 else
                                 {
                                     result.Append(c40char);
+                                    encodedResult.WriteByte((byte)c40char);
                                 }
                             }
                             else
@@ -367,6 +385,7 @@ namespace ZXing.Datamatrix.Internal
                                     case 27: // FNC1
                                         fnc1positions.Add(result.Length);
                                         result.Append((char)29); // translate as ASCII 29
+                                        encodedResult.WriteByte((byte)29);
                                         break;
                                     case 30: // Upper Shift
                                         upperShift = true;
@@ -381,11 +400,13 @@ namespace ZXing.Datamatrix.Internal
                             if (upperShift)
                             {
                                 result.Append((char)(cValue + 224));
+                                encodedResult.WriteByte((byte)(cValue + 224));
                                 upperShift = false;
                             }
                             else
                             {
                                 result.Append((char)(cValue + 96));
+                                encodedResult.WriteByte((byte)(cValue + 96));
                             }
                             shift = 0;
                             break;
@@ -401,7 +422,7 @@ namespace ZXing.Datamatrix.Internal
         /// <summary>
         /// See ISO 16022:2006, 5.2.6 and Annex C, Table C.2
         /// </summary>
-        private static bool decodeTextSegment(BitSource bits, ECIStringBuilder result, List<int> fnc1positions)
+        private static bool decodeTextSegment(BitSource bits, MemoryStream encodedResult, ECIStringBuilder result, List<int> fnc1positions)
         {
             // Three Text values are encoded in a 16-bit value as
             // (1600 * C1) + (40 * C2) + C3 + 1
@@ -442,11 +463,13 @@ namespace ZXing.Datamatrix.Internal
                                 if (upperShift)
                                 {
                                     result.Append((char)(textChar + 128));
+                                    encodedResult.WriteByte((byte)(textChar + 128));
                                     upperShift = false;
                                 }
                                 else
                                 {
                                     result.Append(textChar);
+                                    encodedResult.WriteByte((byte)textChar);
                                 }
                             }
                             else
@@ -458,11 +481,13 @@ namespace ZXing.Datamatrix.Internal
                             if (upperShift)
                             {
                                 result.Append((char)(cValue + 128));
+                                encodedResult.WriteByte((byte)(cValue + 128));
                                 upperShift = false;
                             }
                             else
                             {
                                 result.Append((char)cValue);
+                                encodedResult.WriteByte((byte)cValue);
                             }
                             shift = 0;
                             break;
@@ -474,11 +499,13 @@ namespace ZXing.Datamatrix.Internal
                                 if (upperShift)
                                 {
                                     result.Append((char)(textChar + 128));
+                                    encodedResult.WriteByte((byte)(textChar + 128));
                                     upperShift = false;
                                 }
                                 else
                                 {
                                     result.Append(textChar);
+                                    encodedResult.WriteByte((byte)textChar);
                                 }
                             }
                             else
@@ -488,6 +515,7 @@ namespace ZXing.Datamatrix.Internal
                                     case 27: // FNC1
                                         fnc1positions.Add(result.Length);
                                         result.Append((char)29); // translate as ASCII 29
+                                        encodedResult.WriteByte((byte)29);
                                         break;
                                     case 30: // Upper Shift
                                         upperShift = true;
@@ -505,11 +533,13 @@ namespace ZXing.Datamatrix.Internal
                                 if (upperShift)
                                 {
                                     result.Append((char)(textChar + 128));
+                                    encodedResult.WriteByte((byte)(textChar + 128));
                                     upperShift = false;
                                 }
                                 else
                                 {
                                     result.Append(textChar);
+                                    encodedResult.WriteByte((byte)textChar);
                                 }
                                 shift = 0;
                             }
@@ -531,6 +561,7 @@ namespace ZXing.Datamatrix.Internal
         /// See ISO 16022:2006, 5.2.7
         /// </summary>
         private static bool decodeAnsiX12Segment(BitSource bits,
+                                                 MemoryStream encodedResult,
                                                  ECIStringBuilder result)
         {
             // Three ANSI X12 values are encoded in a 16-bit value as
@@ -560,26 +591,32 @@ namespace ZXing.Datamatrix.Internal
                     {
                         case 0: // X12 segment terminator <CR>
                             result.Append('\r');
+                            encodedResult.WriteByte((byte)'\r');
                             break;
                         case 1: // X12 segment separator *
                             result.Append('*');
+                            encodedResult.WriteByte((byte)'*');
                             break;
                         case 2: // X12 sub-element separator >
                             result.Append('>');
+                            encodedResult.WriteByte((byte)'>');
                             break;
                         case 3: // space
                             result.Append(' ');
+                            encodedResult.WriteByte((byte)' ');
                             break;
                         default:
                             if (cValue < 14)
                             {
                                 // 0 - 9
                                 result.Append((char)(cValue + 44));
+                                encodedResult.WriteByte((byte)(cValue + 44));
                             }
                             else if (cValue < 40)
                             {
                                 // A - Z
                                 result.Append((char)(cValue + 51));
+                                encodedResult.WriteByte((byte)(cValue + 51));
                             }
                             else
                             {
@@ -607,7 +644,7 @@ namespace ZXing.Datamatrix.Internal
         /// <summary>
         /// See ISO 16022:2006, 5.2.8 and Annex C Table C.3
         /// </summary>
-        private static bool decodeEdifactSegment(BitSource bits, ECIStringBuilder result)
+        private static bool decodeEdifactSegment(BitSource bits, MemoryStream encodedResult, ECIStringBuilder result)
         {
             do
             {
@@ -640,6 +677,7 @@ namespace ZXing.Datamatrix.Internal
                         edifactValue |= 0x40; // Add a leading 01 to the 6 bit binary value
                     }
                     result.Append((char)edifactValue);
+                    encodedResult.WriteByte((byte)edifactValue);
                 }
             } while (bits.available() > 0);
 
@@ -650,11 +688,10 @@ namespace ZXing.Datamatrix.Internal
         /// See ISO 16022:2006, 5.2.9 and Annex B, B.2
         /// </summary>
         private static bool decodeBase256Segment(BitSource bits,
-                                                 out byte[] encodedResult,
+                                                 MemoryStream encodedResult,
                                                  ECIStringBuilder result,
                                                  IList<byte[]> byteSegments)
         {
-            encodedResult = null;
             // Figure out how long the Base 256 Segment is.
             int codewordPosition = 1 + bits.ByteOffset; // position is 1-indexed
             int d1 = unrandomize255State(bits.readBits(8), codewordPosition++);
@@ -705,8 +742,7 @@ namespace ZXing.Datamatrix.Internal
                 throw new InvalidOperationException("Platform does not support required encoding: " + uee);
             }
 
-            encodedResult = new byte[bytes.Length];
-            Array.Copy(bytes, encodedResult, bytes.Length);
+            encodedResult.Write(bytes, 0, bytes.Length);
 
             return true;
         }

--- a/Source/lib/maxicode/MaxiCodeReader.cs
+++ b/Source/lib/maxicode/MaxiCodeReader.cs
@@ -66,7 +66,7 @@ namespace ZXing.Maxicode
             if (decoderResult == null)
                 return null;
 
-            var result = new Result(decoderResult.Text, decoderResult.RawBytes, NO_POINTS, BarcodeFormat.MAXICODE);
+            var result = new Result(decoderResult.Text, decoderResult.Data, decoderResult.RawBytes, NO_POINTS, BarcodeFormat.MAXICODE);
 
             var ecLevel = decoderResult.ECLevel;
             if (ecLevel != null)

--- a/Source/lib/maxicode/decoder/DecodedBitStreamParser.cs
+++ b/Source/lib/maxicode/decoder/DecodedBitStreamParser.cs
@@ -77,6 +77,8 @@ namespace ZXing.Maxicode.Internal
                     }
                     String country = getCountry(bytes).ToString(THREE_DIGITS);
                     String service = getServiceClass(bytes).ToString(THREE_DIGITS);
+
+                    var msg = getMessage(bytes, 10, 84);
                     result.Append(getMessage(bytes, 10, 84));
                     if (result.ToString().StartsWith("[)>" + RS + "01" + GS))
                     {
@@ -95,7 +97,7 @@ namespace ZXing.Maxicode.Internal
                     break;
             }
 
-            return new DecoderResult(bytes, result.ToString(), null, mode.ToString());
+            return new DecoderResult(bytes, Encoding.UTF8.GetBytes(result.ToString()), result.ToString(), null, mode.ToString());
         }
 
         private static int getBit(int bit, byte[] bytes)

--- a/Source/lib/qrcode/QRCodeReader.cs
+++ b/Source/lib/qrcode/QRCodeReader.cs
@@ -98,7 +98,7 @@ namespace ZXing.QrCode
                 data.applyMirroredCorrection(points);
             }
 
-            var result = new Result(decoderResult.Text, decoderResult.RawBytes, points, BarcodeFormat.QR_CODE);
+            var result = new Result(decoderResult.Text, decoderResult.Data, decoderResult.RawBytes, points, BarcodeFormat.QR_CODE);
             var byteSegments = decoderResult.ByteSegments;
             if (byteSegments != null)
             {


### PR DESCRIPTION
Hello, I'm using ZXing.Net.Mobile.Forms, which in turn uses ZXing.Net in a specific Xamarin.Forms mobile project.  So I'm absolutely not an expert in the process of barcode decoding. In short, that project scans a barcode that contains some data. However, this data has not 'string' specific format, so we, in fact, want the data as binary. Now we are only using 2 implementations of barcode: Datamatrix and QR. Datamatrix, no problem, we was getting the data by encode the string with ISO-8859-1 and no problem, we could get it. Nevertheless, with QR, that's not the same. When we tried to encode this string with ISO-8859-1 we had lose a lot of information (some characters were mapped to 3f == '?'). So we propose this little alteration, in order to return the text result along with the binary information used to achieve it when applying a specific encoding.