### PR TITLE
added StringRenderer to paste QR and Bar Codes into Text Documents

### DIFF
--- a/Clients/WindowsFormsDemo/WebCam.cs
+++ b/Clients/WindowsFormsDemo/WebCam.cs
@@ -68,7 +68,7 @@ namespace WindowsFormsDemo
             bool moreDevices;
             short index = 0;
 
-            // Load name of all avialable devices into the lstDevices .
+            // Load name of all available devices into the lstDevices .
             do
             {
                 // Get Driver name and version

--- a/Clients/WindowsFormsDemo/WindowsFormsDemoForm.cs
+++ b/Clients/WindowsFormsDemo/WindowsFormsDemoForm.cs
@@ -277,22 +277,39 @@ namespace WindowsFormsDemo
         {
             try
             {
-                var writer = new BarcodeWriter
-                {
-                    Format = (BarcodeFormat)cmbEncoderType.SelectedItem,
-                    Options = EncodingOptions ?? new EncodingOptions
-                    {
-                        Height = picEncodedBarCode.Height,
-                        Width = picEncodedBarCode.Width
-                    },
-                    Renderer = (IBarcodeRenderer<Bitmap>)Activator.CreateInstance(Renderer)
-                };
-                picEncodedBarCode.Image = writer.Write(txtEncoderContent.Text);
+                RenderString();
+                RenderBitmap();
             }
             catch (Exception exc)
             {
                 MessageBox.Show(this, exc.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+        }
+
+        private void RenderString()
+        {
+            var writer = new BarcodeWriter<string>
+            {
+                Format = (BarcodeFormat)cmbEncoderType.SelectedItem,
+                Renderer = new StringRenderer() //.Render(txtEncoderContent.Text);
+            };
+            var str = writer.Write(txtEncoderContent.Text);
+            Clipboard.SetText(str);
+        }
+
+        private void RenderBitmap()
+        {
+            var writer = new BarcodeWriter
+            {
+                Format = (BarcodeFormat)cmbEncoderType.SelectedItem,
+                Options = EncodingOptions ?? new EncodingOptions
+                {
+                    Height = picEncodedBarCode.Height,
+                    Width = picEncodedBarCode.Width
+                },
+                Renderer = (IBarcodeRenderer<Bitmap>)Activator.CreateInstance(Renderer)
+            };
+            picEncodedBarCode.Image = writer.Write(txtEncoderContent.Text);
         }
 
         private void btnEncoderSave_Click(object sender, EventArgs e)

--- a/Source/lib/common/BitMatrix.cs
+++ b/Source/lib/common/BitMatrix.cs
@@ -24,10 +24,10 @@ namespace ZXing.Common
     /// module, x is the column position, and y is the row position. The ordering is always x, y.
     /// The origin is at the top-left.</p>
     ///   <p>Internally the bits are represented in a 1-D array of 32-bit ints. However, each row begins
-    /// with a new int. This is done intentionally so that we can copy out a row into a BitArray very
+    /// with a new int. This is done intentionally so that we can copy out a row into a <see cref="BitArray"/> very
     /// efficiently.</p>
     ///   <p>The ordering of bits is row-major. Within each int, the least significant bits are used first,
-    /// meaning they represent lower x values. This is compatible with BitArray's implementation.</p>
+    /// meaning they represent lower x values. This is compatible with <see cref="BitArray"/>'s implementation.</p>
     /// </summary>
     /// <author>Sean Owen</author>
     /// <author>dswitkin@google.com (Daniel Switkin)</author>

--- a/Source/lib/renderer/StringRenderer.cs
+++ b/Source/lib/renderer/StringRenderer.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * Copyright 2012 ZXing.Net authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+using ZXing.Common;
+
+namespace ZXing.Rendering
+{
+    /// <summary> Renders a <see cref="BitMatrix" /> to a <see cref="string" /> </summary>
+    /// <inheritdoc />
+    public class StringRenderer : IBarcodeRenderer<string>
+    {
+        /// <summary> Foreground/filled Char. </summary>
+        public Char Foreground { get; set; } = '█';
+
+        /// <summary> Background/blank Char. </summary>
+        public Char Background { get; set; } = ' ';
+
+        [System.CLSCompliant(false)]
+        public string Render(BitMatrix matrix, BarcodeFormat format, string content) => Render(matrix, format, content, null);
+
+        [System.CLSCompliant(false)]
+        public string Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
+        {
+            int height = matrix.Height;
+            int width = matrix.Width + LineFeed.Length;
+            char[] matrixTxt = new char[width * height];
+            for (int i, y = i = 0; y < matrix.Height; y++)
+            {
+                for (var x = 0; x < matrix.Width; x++)
+                {
+                    matrixTxt[i++] = matrix[x, y] ? Foreground : Background;
+                }
+                foreach (var lf in LineFeed)
+                {
+                    matrixTxt[i++] = lf;
+                }
+            }
+
+            return new string(matrixTxt);
+        }
+
+        public string LineFeed { get; set; } = "\n";
+    }
+}

--- a/Source/lib/uwp/zxing.uwp.csproj
+++ b/Source/lib/uwp/zxing.uwp.csproj
@@ -944,6 +944,9 @@
     <Compile Include="..\renderer\SoftwareBitmapRenderer.cs">
       <Link>renderer\SoftwareBitmapRenderer.cs</Link>
     </Compile>
+    <Compile Include="..\renderer\StringRenderer.cs">
+      <Link>renderer\StringRenderer.cs</Link>
+    </Compile>
     <Compile Include="..\renderer\SVGRenderer.cs">
       <Link>renderer\SVGRenderer.cs</Link>
     </Compile>

--- a/Source/lib/zxing.net4.0.csproj
+++ b/Source/lib/zxing.net4.0.csproj
@@ -401,6 +401,7 @@
     <Compile Include="renderer\PixelData.Bitmap.cs" />
     <Compile Include="renderer\PixelData.cs" />
     <Compile Include="renderer\PixelDataRenderer.cs" />
+    <Compile Include="renderer\StringRenderer.cs" />
     <Compile Include="renderer\SvgRenderer.cs" />
     <Compile Include="Result.cs" />
     <Compile Include="ResultMetadataType.cs" />


### PR DESCRIPTION
Hi, I added an IBarcodeRenderer<string> to be able to generate QR and Bar Codes Strings for use in Text Documents and Markdown Files. 
I also modified the Windows Client App to add the generated Code to the Clipboard for easy access 