### PR TITLE
Use a "margin" wide quiet space on both sides of a 1D barcode

### DIFF
--- a/Source/lib/oned/OneDimensionalCodeWriter.cs
+++ b/Source/lib/oned/OneDimensionalCodeWriter.cs
@@ -131,18 +131,17 @@ namespace ZXing.OneD
         {
             int inputWidth = code.Length;
             // Add quiet zone on both sides.
-            int fullWidth = inputWidth + sidesMargin;
+            int fullWidth = inputWidth + sidesMargin * 2;
             int outputWidth = Math.Max(width, fullWidth);
             int outputHeight = Math.Max(1, height);
 
             int multiple = outputWidth / fullWidth;
             int leftPadding = (outputWidth - (inputWidth * multiple)) / 2;
 
-
             if (noPadding)
             {
-                outputWidth -= (leftPadding - sidesMargin) * 2;
-                leftPadding = sidesMargin;
+                outputWidth = fullWidth * multiple;
+                leftPadding = sidesMargin * multiple;
             }
 
             BitMatrix output = new BitMatrix(outputWidth, outputHeight);


### PR DESCRIPTION
Current implementation is using the specified margin as total margin (left + right) for 1D barcodes. This makes the default value of 10x too small in some cases, making the barcode difficult to read.
The default margin value of 10 is consistent with many standards when applied to both sides, so this PR uses the specified margin value on each side.
This is fixing #480 .