### PR TITLE
Add ResultMetadata.QR_MASK_PATTERN to QR codes

### DIFF
--- a/Source/lib/ResultMetadataType.cs
+++ b/Source/lib/ResultMetadataType.cs
@@ -103,6 +103,11 @@ namespace ZXing
         /// Barcode Symbology Identifier.
         /// Note: According to the GS1 specification the identifier may have to replace a leading FNC1/GS character when prepending to the barcode content.
         /// </summary>
-        SYMBOLOGY_IDENTIFIER
+        SYMBOLOGY_IDENTIFIER,
+
+        /// <summary>
+        /// The bit mask applied to a QR code
+        /// </summary>
+        QR_MASK_PATTERN
     }
 }

--- a/Source/lib/multi/qrcode/QRCodeMultiReader.cs
+++ b/Source/lib/multi/qrcode/QRCodeMultiReader.cs
@@ -59,7 +59,7 @@ namespace ZXing.Multi.QrCode
                 var points = detectorResult.Points;
                 // If the code was mirrored: swap the bottom-left and the top-right points.
                 var data = decoderResult.Other as QRCodeDecoderMetaData;
-                if (data != null)
+                if (data != null && data.IsMirrored)
                 {
                     data.applyMirroredCorrection(points);
                 }

--- a/Source/lib/multi/qrcode/QRCodeMultiReader.cs
+++ b/Source/lib/multi/qrcode/QRCodeMultiReader.cs
@@ -64,6 +64,12 @@ namespace ZXing.Multi.QrCode
                     data.applyMirroredCorrection(points);
                 }
                 var result = new Result(decoderResult.Text, decoderResult.RawBytes, points, BarcodeFormat.QR_CODE);
+
+                if (data != null)
+                {
+                    result.putMetadata(ResultMetadataType.QR_MASK_PATTERN, data.DataMask);
+                }
+
                 var byteSegments = decoderResult.ByteSegments;
                 if (byteSegments != null)
                 {

--- a/Source/lib/qrcode/QRCodeReader.cs
+++ b/Source/lib/qrcode/QRCodeReader.cs
@@ -99,6 +99,12 @@ namespace ZXing.QrCode
             }
 
             var result = new Result(decoderResult.Text, decoderResult.RawBytes, points, BarcodeFormat.QR_CODE);
+
+            if (data != null)
+            {
+                result.putMetadata(ResultMetadataType.QR_MASK_PATTERN, data.DataMask);
+            }
+
             var byteSegments = decoderResult.ByteSegments;
             if (byteSegments != null)
             {

--- a/Source/lib/qrcode/QRCodeReader.cs
+++ b/Source/lib/qrcode/QRCodeReader.cs
@@ -93,7 +93,7 @@ namespace ZXing.QrCode
 
             // If the code was mirrored: swap the bottom-left and the top-right points.
             var data = decoderResult.Other as QRCodeDecoderMetaData;
-            if (data != null)
+            if (data != null && data.IsMirrored)
             {
                 data.applyMirroredCorrection(points);
             }

--- a/Source/lib/qrcode/decoder/Decoder.cs
+++ b/Source/lib/qrcode/decoder/Decoder.cs
@@ -70,7 +70,13 @@ namespace ZXing.QrCode.Internal
                 return null;
 
             var result = decode(parser, hints);
-            if (result == null)
+
+            if (result != null)
+            {
+                result.Other = new QRCodeDecoderMetaData(false, parser.readFormatInformation().DataMask);
+                return result;
+            }
+            else
             {
                 // Revert the bit matrix
                 parser.remask();
@@ -101,12 +107,11 @@ namespace ZXing.QrCode.Internal
 
                 if (result != null)
                 {
-                    // Success! Notify the caller that the code was mirrored.
-                    result.Other = new QRCodeDecoderMetaData(true);
+                    // Success! Notify the caller that the QRCode was mirrored
+                    result.Other = new QRCodeDecoderMetaData(true, formatinfo.DataMask);
                 }
+                return result;
             }
-
-            return result;
         }
 
         private DecoderResult decode(BitMatrixParser parser, IDictionary<DecodeHintType, object> hints)

--- a/Source/lib/qrcode/decoder/QRCodeDecoderMetaData.cs
+++ b/Source/lib/qrcode/decoder/QRCodeDecoderMetaData.cs
@@ -23,14 +23,17 @@ namespace ZXing.QrCode.Internal
     public sealed class QRCodeDecoderMetaData
     {
         private readonly bool mirrored;
+        private readonly int dataMask;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QRCodeDecoderMetaData"/> class.
         /// </summary>
         /// <param name="mirrored">if set to <c>true</c> [mirrored].</param>
-        public QRCodeDecoderMetaData(bool mirrored)
+        /// <param name="dataMask">The mask applied to the bit matrix</param>
+        public QRCodeDecoderMetaData(bool mirrored, int dataMask)
         {
             this.mirrored = mirrored;
+            this.dataMask = dataMask;
         }
 
         /// <summary>
@@ -39,6 +42,15 @@ namespace ZXing.QrCode.Internal
         public bool IsMirrored
         {
             get { return mirrored; }
+        }
+
+
+        /// <summary>
+        /// The mask applied to the QR code
+        /// </summary>
+        public int DataMask
+        {
+            get { return dataMask; }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds `ResultMetadata.QR_MASK_PATTERN` when reading QR codes.

I ran into an issue where I was unable to generate an exact copy of a scanned QR code, and subsequently identified the issue being that ZXing selects the 'best' mask pattern. To be able to generate the exact same code, I need to specify the mask pattern ( for which an hint already exists) and hence need to pass the metadata from the reader to the upper-level program.

This enables the possibility of reading a QR code (i.e. from a photo) and generating a pristine bitmap of the same QR code using `EncodeHintType.QR_MASK_PATTERN`.