### PR TITLE
Added TryInverted option and GlobalHistogramBinarizer fallback

### DIFF
--- a/Clients/CommandLineDecoder/Config.cs
+++ b/Clients/CommandLineDecoder/Config.cs
@@ -25,6 +25,7 @@ namespace CommandLineDecoder
     {
         public IDictionary<DecodeHintType, object> Hints { get; set; }
         public bool TryHarder { get; set; }
+        public bool TryInverted { get; set; }
         public bool PureBarcode { get; set; }
         public bool ProductsOnly { get; set; }
         public bool DumpResults { get; set; }

--- a/Clients/CommandLineDecoder/DecodeThread.cs
+++ b/Clients/CommandLineDecoder/DecodeThread.cs
@@ -206,9 +206,8 @@ namespace CommandLineDecoder
                 reader.Options.Hints.Add(entry.Key, entry.Value);
             Result result = reader.Decode(source);
 
-            if (result == null)
+            if (config.TryHarder && result == null)
             {
-                // Explicitly use the GlobalHistogramBinarizer if nothing is found with the HybridBinarizer
                 reader = new BarcodeReader(null, null, s => new GlobalHistogramBinarizer(s));
                 foreach (var entry in hints)
                     reader.Options.Hints.Add(entry.Key, entry.Value);
@@ -281,9 +280,8 @@ namespace CommandLineDecoder
                     reader.Options.Hints.Add(entry.Key, entry.Value);
                 Result[] results = reader.DecodeMultiple(source);
 
-                if (results == null || results.Length == 0)
+                if (config.TryHarder && results == null || results.Length == 0)
                 {
-                    // Explicitly use the GlobalHistogramBinarizer if nothing is found with the HybridBinarizer
                     reader = new BarcodeReader(null, null, s => new GlobalHistogramBinarizer(s));
                     foreach (var entry in hints)
                         reader.Options.Hints.Add(entry.Key, entry.Value);

--- a/Clients/CommandLineDecoder/DecodeThread.cs
+++ b/Clients/CommandLineDecoder/DecodeThread.cs
@@ -205,6 +205,16 @@ namespace CommandLineDecoder
             foreach (var entry in hints)
                 reader.Options.Hints.Add(entry.Key, entry.Value);
             Result result = reader.Decode(source);
+
+            if (result == null)
+            {
+                // Explicitly use the GlobalHistogramBinarizer if nothing is found with the HybridBinarizer
+                reader = new BarcodeReader(null, null, s => new GlobalHistogramBinarizer(s));
+                foreach (var entry in hints)
+                    reader.Options.Hints.Add(entry.Key, entry.Value);
+                result = reader.Decode(source);
+            }
+
             if (result != null)
             {
                 if (config.Brief)
@@ -270,6 +280,16 @@ namespace CommandLineDecoder
                 foreach (var entry in hints)
                     reader.Options.Hints.Add(entry.Key, entry.Value);
                 Result[] results = reader.DecodeMultiple(source);
+
+                if (results == null || results.Length == 0)
+                {
+                    // Explicitly use the GlobalHistogramBinarizer if nothing is found with the HybridBinarizer
+                    reader = new BarcodeReader(null, null, s => new GlobalHistogramBinarizer(s));
+                    foreach (var entry in hints)
+                        reader.Options.Hints.Add(entry.Key, entry.Value);
+                    results = reader.DecodeMultiple(source);
+                }
+
                 if (results != null && results.Length > 0)
                 {
                     if (config.Brief)

--- a/Clients/CommandLineDecoder/Program.cs
+++ b/Clients/CommandLineDecoder/Program.cs
@@ -47,6 +47,10 @@ namespace CommandLineDecoder
                 {
                     config.TryHarder = true;
                 }
+                else if ("--try_inverted".Equals(arg))
+                {
+                    config.TryInverted = true;
+                }
                 else if ("--pure_barcode".Equals(arg))
                 {
                     config.PureBarcode = true;
@@ -235,6 +239,10 @@ namespace CommandLineDecoder
             {
                 hints[DecodeHintType.TRY_HARDER] = true;
             }
+            if (config.TryInverted)
+            {
+                hints[DecodeHintType.ALSO_INVERTED] = true;
+            }
             if (config.PureBarcode)
             {
                 hints[DecodeHintType.PURE_BARCODE] = true;
@@ -247,6 +255,7 @@ namespace CommandLineDecoder
             Console.Out.WriteLine("Decode barcode images using the ZXing library\n");
             Console.Out.WriteLine("usage: CommandLineRunner { file | dir | url } [ options ]");
             Console.Out.WriteLine("  --try_harder: Use the TRY_HARDER hint, default is normal (mobile) mode");
+            Console.Out.WriteLine("  --try_inverted: Decode the image inverted if normal mode fails");
             Console.Out.WriteLine("  --pure_barcode: Input image is a pure monochrome barcode image, not a photo");
             Console.Out.WriteLine("  --products_only: Only decode the UPC and EAN families of barcodes");
             Console.Out.WriteLine("  --dump_results: Write the decoded contents to input.txt");


### PR DESCRIPTION
- TryInverted option
    Allow enabling ALSO_INVERTED decode hint in command line arguments
- GlobalHistogramBinarizer fallback
    Explicitly use the GlobalHistogramBinarizer if nothing is found with the HybridBinarizer     
    https://github.com/micjahn/ZXing.Net/issues/145