### PR TITLE
Update Code128Writer

### DIFF
--- a/Source/lib/oned/Code128Writer.cs
+++ b/Source/lib/oned/Code128Writer.cs
@@ -82,7 +82,7 @@ namespace ZXing.OneD
         /// <param name="contents"></param>
         /// <param name="hints"></param>
         /// <returns></returns>
-        protected override bool[] encode(String contents, IDictionary<EncodeHintType, object> hints)
+        public override bool[] encode(String contents, IDictionary<EncodeHintType, object> hints)
         {
             if (IDictionaryExtensions.IsBooleanFlagSet(hints, EncodeHintType.GS1_FORMAT))
             {
@@ -163,7 +163,7 @@ namespace ZXing.OneD
                         break;
                     case CODE_CODE_B:
                         // allows no ascii below 32 (terminal symbols)
-                        if (c <= 32)
+                        if (c < 32)
                         {
                             throw new ArgumentException("Bad character in input for forced code set B: ASCII value=" + (int)c);
                         }

--- a/Source/lib/oned/OneDimensionalCodeWriter.cs
+++ b/Source/lib/oned/OneDimensionalCodeWriter.cs
@@ -48,7 +48,7 @@ namespace ZXing.OneD
         /// <param name="contents">barcode contents to encode</param>
         /// <param name="hints">encoding hints</param>
         /// <returns>a <c>bool[]</c> of horizontal pixels (false = white, true = black)</returns>
-        protected virtual bool[] encode(String contents, IDictionary<EncodeHintType, object> hints)
+        public virtual bool[] encode(String contents, IDictionary<EncodeHintType, object> hints)
         {
             return encode(contents);
         }


### PR DESCRIPTION
This update makes two changes:

1. Allow space in Code128 CodeSet B
2. Make `OneDimensionalCodeWriter.encode(contents, hints)` public

Both changes have already been approved and merged in the parent project:
https://github.com/zxing/zxing/pull/1658
https://github.com/zxing/zxing/pull/1659