### PR TITLE
Fix COPYING by adding Copyright statement

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -175,18 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2012-2023 ZXing.Net authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I believe it is preferable to have "Copyright" explicitly stated in the license text for the purpose of indicating the license for derivative software.

In this pull request, I added the copyright notice following the example below for reference.
https://github.com/zxing/zxing/blob/master/LICENSE
https://github.com/ionic-team/ionic-site/blob/main/LICENSE ([Library used in VSCode](https://github.com/microsoft/vscode/blob/main/ThirdPartyNotices.txt))
https://github.com/moby/moby/blob/master/LICENSE ([Library used in VSCode](https://github.com/microsoft/vscode/blob/main/ThirdPartyNotices.txt))
