### PR TITLE
SKBitmapRenderer.Render virtual for extensibility

### DIFF
--- a/Source/Bindings/ZXing.SkiaSharp/Renderer/SKBitmapRenderer.cs
+++ b/Source/Bindings/ZXing.SkiaSharp/Renderer/SKBitmapRenderer.cs
@@ -98,7 +98,7 @@ namespace ZXing.SkiaSharp.Rendering
         /// <param name="content">The content.</param>
         /// <param name="options">The options.</param>
         /// <returns></returns>
-        public SKBitmap Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
+        virtual public SKBitmap Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
         {
             var width = matrix.Width;
             var height = matrix.Height;


### PR DESCRIPTION
Made SKBitmapRenderer.Render virtual, just like BitmapRenderer.Render, because a solution like the one presented in issue #38 is not available for Skia due to this difference.

Kind regards and thank you for this excellent library!