### PR TITLE
ResultPoints are not always correctly rotated back

### DIFF
--- a/Source/lib/BarcodeReaderGeneric.cs
+++ b/Source/lib/BarcodeReaderGeneric.cs
@@ -243,7 +243,8 @@ namespace ZXing
 
             if (result != null)
             {
-                TranslateResultPointsBack(result, rotationCount, originalWidth, originalHeight);
+                if (result.ResultPoints != null)
+                    ResultPoint.TranslateResultPointsBack(result.ResultPoints, rotationCount * 90, originalWidth, originalHeight);
 
                 if (result.ResultMetadata == null)
                 {
@@ -320,7 +321,8 @@ namespace ZXing
             {
                 foreach (var result in results)
                 {
-                    TranslateResultPointsBack(result, rotationCount, originalWidth, originalHeight);
+                    if (result.ResultPoints != null)
+                        ResultPoint.TranslateResultPointsBack(result.ResultPoints, rotationCount * 90, originalWidth, originalHeight);
 
                     if (result.ResultMetadata == null)
                     {
@@ -342,39 +344,6 @@ namespace ZXing
             }
 
             return results;
-        }
-
-        private static void TranslateResultPointsBack(Result result, int rotationCount, int originalWidth, int originalHeight)
-        {
-            if (result == null ||
-                result.ResultPoints == null ||
-                result.ResultPoints.Length == 0)
-                return;
-
-            rotationCount = rotationCount % 4;
-            if (rotationCount == 0)
-                return;
-
-            var points = result.ResultPoints;
-            for (var index = 0; index < points.Length; index++)
-            {
-                points[index] = TranslateResultPointBack(points[index], rotationCount, originalWidth, originalHeight);
-            }
-        }
-
-        private static ResultPoint TranslateResultPointBack(ResultPoint point, int rotationCount, int originalWidth, int originalHeight)
-        {
-            switch (rotationCount)
-            {
-                case 1:
-                    return new ResultPoint(originalWidth - point.Y - 1, point.X);
-                case 2:
-                    return new ResultPoint(originalWidth - point.X - 1, originalHeight - point.Y - 1);
-                case 3:
-                    return new ResultPoint(point.Y, originalHeight - point.X - 1);
-                default:
-                    return point;
-            }
         }
 
         /// <summary>

--- a/Source/lib/BarcodeReaderGeneric.cs
+++ b/Source/lib/BarcodeReaderGeneric.cs
@@ -200,6 +200,8 @@ namespace ZXing
         public virtual Result Decode(LuminanceSource luminanceSource)
         {
             var result = default(Result);
+            var originalWidth = luminanceSource.Width;
+            var originalHeight = luminanceSource.Height;
             var binarizer = CreateBinarizer(luminanceSource);
             var binaryBitmap = new BinaryBitmap(binarizer);
             var multiformatReader = Reader as MultiFormatReader;
@@ -241,6 +243,8 @@ namespace ZXing
 
             if (result != null)
             {
+                TranslateResultPointsBack(result, rotationCount, originalWidth, originalHeight);
+
                 if (result.ResultMetadata == null)
                 {
                     result.putMetadata(ResultMetadataType.ORIENTATION, rotationCount * 90);
@@ -273,6 +277,8 @@ namespace ZXing
         public virtual Result[] DecodeMultiple(LuminanceSource luminanceSource)
         {
             var results = default(Result[]);
+            var originalWidth = luminanceSource.Width;
+            var originalHeight = luminanceSource.Height;
             var binarizer = CreateBinarizer(luminanceSource);
             var binaryBitmap = new BinaryBitmap(binarizer);
             var rotationCount = 0;
@@ -306,13 +312,16 @@ namespace ZXing
                     !AutoRotate)
                     break;
 
-                binaryBitmap = new BinaryBitmap(CreateBinarizer(luminanceSource.rotateCounterClockwise()));
+                luminanceSource = luminanceSource.rotateCounterClockwise();
+                binaryBitmap = new BinaryBitmap(CreateBinarizer(luminanceSource));
             }
 
             if (results != null)
             {
                 foreach (var result in results)
                 {
+                    TranslateResultPointsBack(result, rotationCount, originalWidth, originalHeight);
+
                     if (result.ResultMetadata == null)
                     {
                         result.putMetadata(ResultMetadataType.ORIENTATION, rotationCount * 90);
@@ -333,6 +342,39 @@ namespace ZXing
             }
 
             return results;
+        }
+
+        private static void TranslateResultPointsBack(Result result, int rotationCount, int originalWidth, int originalHeight)
+        {
+            if (result == null ||
+                result.ResultPoints == null ||
+                result.ResultPoints.Length == 0)
+                return;
+
+            rotationCount = rotationCount % 4;
+            if (rotationCount == 0)
+                return;
+
+            var points = result.ResultPoints;
+            for (var index = 0; index < points.Length; index++)
+            {
+                points[index] = TranslateResultPointBack(points[index], rotationCount, originalWidth, originalHeight);
+            }
+        }
+
+        private static ResultPoint TranslateResultPointBack(ResultPoint point, int rotationCount, int originalWidth, int originalHeight)
+        {
+            switch (rotationCount)
+            {
+                case 1:
+                    return new ResultPoint(originalWidth - point.Y - 1, point.X);
+                case 2:
+                    return new ResultPoint(originalWidth - point.X - 1, originalHeight - point.Y - 1);
+                case 3:
+                    return new ResultPoint(point.Y, originalHeight - point.X - 1);
+                default:
+                    return point;
+            }
         }
 
         /// <summary>

--- a/Source/lib/ResultPoint.cs
+++ b/Source/lib/ResultPoint.cs
@@ -183,6 +183,58 @@ namespace ZXing
             return MathUtils.distance(pattern1.x, pattern1.y, pattern2.x, pattern2.y);
         }
 
+        internal static void TranslateResultPointsBack(ResultPoint[] points, int rotation, int originalWidth, int originalHeight)
+        {
+            if (points == null || points.Length == 0)
+            {
+                return;
+            }
+
+            rotation = ((rotation % 360) + 360) % 360;
+            if (rotation == 0)
+            {
+                return;
+            }
+
+            for (int i = 0; i < points.Length; i++)
+            {
+                points[i] = TranslateResultPointBack(points[i], rotation, originalWidth, originalHeight);
+            }
+        }
+
+        internal static ResultPoint[] TranslateResultPointsBackCopy(ResultPoint[] points, int rotation, int originalWidth, int originalHeight)
+        {
+            if (points == null || points.Length == 0)
+            {
+                return points;
+            }
+
+            var translatedPoints = new ResultPoint[points.Length];
+            Array.Copy(points, translatedPoints, points.Length);
+            TranslateResultPointsBack(translatedPoints, rotation, originalWidth, originalHeight);
+            return translatedPoints;
+        }
+
+        private static ResultPoint TranslateResultPointBack(ResultPoint point, int rotation, int originalWidth, int originalHeight)
+        {
+            if (point == null)
+            {
+                return null;
+            }
+
+            switch (rotation)
+            {
+                case 90:
+                    return new ResultPoint(originalWidth - point.Y - 1, point.X);
+                case 180:
+                    return new ResultPoint(originalWidth - point.X - 1, originalHeight - point.Y - 1);
+                case 270:
+                    return new ResultPoint(point.Y, originalHeight - point.X - 1);
+                default:
+                    return point;
+            }
+        }
+
         /// <summary>
         /// Returns the z component of the cross product between vectors BC and BA.
         /// </summary>

--- a/Source/lib/pdf417/PDF417Reader.cs
+++ b/Source/lib/pdf417/PDF417Reader.cs
@@ -129,7 +129,7 @@ namespace ZXing.PDF417
                     {
                         continue;
                     }
-                    var result = new Result(decoderResult.Text, decoderResult.RawBytes, points, BarcodeFormat.PDF_417);
+                    var result = new Result(decoderResult.Text, decoderResult.RawBytes, ResultPoint.TranslateResultPointsBackCopy(points, detectorResult.Rotation, image.Width, image.Height), BarcodeFormat.PDF_417);
                     result.putMetadata(ResultMetadataType.ERROR_CORRECTION_LEVEL, decoderResult.ECLevel);
                     result.putMetadata(ResultMetadataType.ERRORS_CORRECTED, decoderResult.ErrorsCorrected);
                     result.putMetadata(ResultMetadataType.ERASURES_CORRECTED, decoderResult.Erasures);


### PR DESCRIPTION
I noticed when detecting PDF417 barcodes that the detector sometimes returned the incorrect coordinates. I believe that this fix corrects that issue.