### PR TITLE
Update ZXing.Net.csproj to define NETSTANDARD2_0_OR_GREATER

### DIFF
--- a/Source/lib/netstandard/ZXing.Net.csproj
+++ b/Source/lib/netstandard/ZXing.Net.csproj
@@ -54,39 +54,39 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETSTANDARD2_0_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETCOREAPP3_0;WPF</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETSTANDARD2_0_OR_GREATER;NETCOREAPP3_0;WPF</DefineConstants>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETCOREAPP3_1;WPF</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETSTANDARD2_0_OR_GREATER;NETCOREAPP3_1;WPF</DefineConstants>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETSTANDARD2_0_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETSTANDARD2_0_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net7.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETSTANDARD2_0_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETSTANDARD2_0_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net9.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;NETSTANDARD2_0_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Work Performed
- Fix for issue #628 by adding the definitions for `NETSTANDARD2_0_OR_GREATER` to the project.
- Line endings automatically normalized per GitHub online editor.

### Testing
Built ZXing.Net.csproj locally and decompiled the .NET5+ DLLs to confirm that they use `System.Drawing.Color` for `SvgRenderer.Background` and `SvgRenderer.Foreground`.