### PR TITLE
Add ZXing.ImageSharp.V4 binding for SixLabors.ImageSharp 4.0

### DIFF
--- a/Source/Bindings/Tests/ZXing.ImageSharp.V4/ImageSharpLuminanceSourceTests.cs
+++ b/Source/Bindings/Tests/ZXing.ImageSharp.V4/ImageSharpLuminanceSourceTests.cs
@@ -1,0 +1,202 @@
+/*
+* Copyright 2013 ZXing.Net authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace ZXing.ImageSharp.Test
+{
+    using NUnit.Framework;
+    using System;
+    using System.Drawing;
+    using System.IO;
+    using System.Runtime.Versioning;
+    using ZXing.Windows.Compatibility;
+    using SelectedPixelFormat = SixLabors.ImageSharp.PixelFormats.Argb32;
+
+    [TestFixture]
+    [SupportedOSPlatform("windows")]
+    public class ImageSharpLuminanceSourceTests
+    {
+        [TestCase("../../../../../test/data/luminance/qr-code-abc-Format1bppIndexed.bmp", "abc")]
+        [TestCase("../../../../../test/data/luminance/qr-code-abc-Format4bppIndexed.bmp", "abc")]
+        [TestCase("../../../../../test/data/luminance/qr-code-abc-Format8bppIndexed.bmp", "abc")]
+        [TestCase("../../../../../test/data/luminance/qr-code-abc-Format16bppRgb565.bmp", "abc")]
+        [TestCase("../../../../../test/data/luminance/qr-code-abc-Format24bppRgb.bmp", "abc")]
+        [TestCase("../../../../../test/data/luminance/qr-code-abc-Format32bppRgb.bmp", "abc")]
+        [TestCase("../../../../../test/data/luminance/qr-code-abc-Format32bppArgb.bmp", "abc")]
+        [TestCase("../../../../../test/data/luminance/qr-code-abc-Format16bppRgb555.bmp", "abc")]
+        [TestCase("../../../../../test/data/luminance/qr-code-abc-Format16bppArgb1555.bmp", "abc")]
+        public void Should_Calculate_Luminance_And_Decode(string fileName, string content)
+        {
+            using (var bitmap = LoadImageSharpBitmap(fileName))
+            {
+                var luminance = new ImageSharpLuminanceSource<SelectedPixelFormat>(bitmap);
+                var reader = new BarcodeReader<SelectedPixelFormat>();
+                var result = reader.Decode(luminance);
+                Assert.That(result?.Text, Is.EqualTo(content));
+            }
+        }
+
+        [TestCase("../../../../../test/data/blackbox/falsepositives/20.png")]
+        [TestCase("../../../../../test/data/blackbox/upce-2/36.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-5/15.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-4/05.png")]
+        [TestCase("../../../../../test/data/blackbox/code128-2/37.png")]
+        [TestCase("../../../../../test/data/blackbox/partial/16.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-4/25.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-3/33.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-2/19.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpandedstacked-1/45.png")]
+        [TestCase("../../../../../test/data/blackbox/upca-2/35.png")]
+        [TestCase("../../../../../test/data/blackbox/rss14-2/1.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpandedstacked-1/12.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-2/13.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpanded-3/49.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpandedstacked-1/39.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-2/28.png")]
+        [TestCase("../../../../../test/data/blackbox/code39-3/08.png")]
+        [TestCase("../../../../../test/data/blackbox/upce-2/03.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-5/06.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpanded-3/18.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-3/28.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-1/10.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpanded-3/114.png")]
+        [TestCase("../../../../../test/data/blackbox/pdf417-3/19.png")]
+        [TestCase("../../../../../test/data/blackbox/upca-6/04.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-1/30.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-4/44.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpanded-3/115.png")]
+        [TestCase("../../../../../test/data/benchmark/android-2/ean13-1.png")]
+        [TestCase("../../../../../test/data/blackbox/codabar-1/09.png")]
+        [TestCase("../../../../../test/data/blackbox/itf-2/08.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-3/23.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-5/03.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-5/02.png")]
+        [TestCase("../../../../../test/data/blackbox/pdf417-3/04.png")]
+        [TestCase("../../../../../test/data/blackbox/partial/23.png")]
+        [TestCase("../../../../../test/data/blackbox/upce-2/21.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-1/31.png")]
+        [TestCase("../../../../../test/data/blackbox/rss14-1/4.png")]
+        [TestCase("../../../../../test/data/blackbox/falsepositives/18.png")]
+        [TestCase("../../../../../test/data/blackbox/datamatrix-2/13.png")]
+        [TestCase("../../../../../test/data/blackbox/partial/08.png")]
+        [TestCase("../../../../../test/data/blackbox/code128-2/33.png")]
+        [TestCase("../../../../../test/data/blackbox/upcean-extension-1/1.png")]
+        [TestCase("../../../../../test/data/blackbox/aztec-1/lorem-075x075.png")]
+        [TestCase("../../../../../test/data/blackbox/datamatrix-2/14.png")]
+        [TestCase("../../../../../test/data/blackbox/codabar-1/02.png")]
+        [TestCase("../../../../../test/data/blackbox/partial/15.png")]
+        [TestCase("../../../../../test/data/blackbox/upca-2/18.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpanded-3/25.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-1/13.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-5/13.png")]
+        [TestCase("../../../../../test/data/blackbox/itf-2/05.png")]
+        [TestCase("../../../../../test/data/blackbox/imb-1/04.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpanded-3/106.png")]
+        [TestCase("../../../../../test/data/blackbox/upca-6/05.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-3/10.png")]
+        [TestCase("../../../../../test/data/benchmark/android-2/fail-2.png")]
+        [TestCase("../../../../../test/data/blackbox/datamatrix-1/GUID.png")]
+        [TestCase("../../../../../test/data/blackbox/upca-4/5.png")]
+        [TestCase("../../../../../test/data/blackbox/upca-1/29.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-4/14.png")]
+        [TestCase("../../../../../test/data/blackbox/falsepositives-2/12.png")]
+        [TestCase("../../../../../test/data/blackbox/upcean-extension-1/2.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-1/3.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-2/23.png")]
+        [TestCase("../../../../../test/data/blackbox/codabar-1/12.png")]
+        [TestCase("../../../../../test/data/blackbox/itf-2/10.png")]
+        [TestCase("../../../../../test/data/blackbox/code128-2/34.png")]
+        [TestCase("../../../../../test/data/blackbox/datamatrix-2/04.png")]
+        [TestCase("../../../../../test/data/blackbox/partial/31.png")]
+        [TestCase("../../../../../test/data/blackbox/upca-2/49.png")]
+        [TestCase("../../../../../test/data/blackbox/rssexpanded-3/102.png")]
+        [TestCase("../../../../../test/data/blackbox/upca-5/15.png")]
+        [TestCase("../../../../../test/data/blackbox/imb-1/09.png")]
+        [TestCase("../../../../../test/data/blackbox/ean13-3/14.png")]
+        [TestCase("../../../../../test/data/blackbox/pdf417-2/14.png")]
+        [TestCase("../../../../../test/data/blackbox/qrcode-4/22.png")]
+        public void Luminance_Is_Within_Margin_Of_Error(string fileName)
+        {
+            byte[] controlLuminanceSourceMatrix;
+            using (var control = LoadBitmapImage(fileName))
+            {
+                var bitmapLuminanceSource = new BitmapLuminanceSource(control);
+                controlLuminanceSourceMatrix = bitmapLuminanceSource.Matrix;
+            }
+
+            byte[] testLuminanceSourceMatrix;
+            using (var bitmap = LoadImageSharpBitmap(fileName))
+            {
+                var imagesharpBitmapLuminanceSource = new ImageSharpLuminanceSource<SelectedPixelFormat>(bitmap);
+                testLuminanceSourceMatrix = imagesharpBitmapLuminanceSource.Matrix;
+            }
+
+            Assert.AreEqual(controlLuminanceSourceMatrix.Length, testLuminanceSourceMatrix.Length);
+
+            for (int index = 0; index < controlLuminanceSourceMatrix.Length; index++)
+            {
+                var controlColor = controlLuminanceSourceMatrix[index];
+                var testColor = testLuminanceSourceMatrix[index];
+
+                Assert.That(testColor, Is.EqualTo(controlColor).Within(3));
+            }
+        }
+
+        private static string ResolveTestDataFile(string fileName)
+        {
+            var normalized = fileName.Replace('\\', '/');
+            while (normalized.StartsWith("../", StringComparison.Ordinal))
+            {
+                normalized = normalized.Substring(3);
+            }
+
+            var candidates = new System.Collections.Generic.List<string>
+            {
+                Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, fileName)),
+                Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", fileName))
+            };
+
+            var dir = TestContext.CurrentContext.TestDirectory;
+            for (int i = 0; i < 10 && !string.IsNullOrEmpty(dir); i++)
+            {
+                candidates.Add(Path.GetFullPath(Path.Combine(dir, normalized)));
+                candidates.Add(Path.GetFullPath(Path.Combine(dir, "Source", normalized)));
+                dir = Path.GetDirectoryName(dir);
+            }
+
+            foreach (var candidate in candidates)
+            {
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            Assert.Fail($"Test data file not found: {fileName}");
+            return null;
+        }
+
+        private static SixLabors.ImageSharp.Image<SelectedPixelFormat> LoadImageSharpBitmap(string fileName)
+        {
+            return SixLabors.ImageSharp.Image.Load<SelectedPixelFormat>(ResolveTestDataFile(fileName));
+        }
+
+        private static Bitmap LoadBitmapImage(string fileName)
+        {
+            return (Bitmap)Image.FromFile(ResolveTestDataFile(fileName));
+        }
+
+    }
+}

--- a/Source/Bindings/Tests/ZXing.ImageSharp.V4/RenderingTests.cs
+++ b/Source/Bindings/Tests/ZXing.ImageSharp.V4/RenderingTests.cs
@@ -1,0 +1,79 @@
+
+namespace ZXing.ImageSharp.Test
+{
+    using System;
+
+    using NUnit.Framework;
+
+    using SelectedPixelFormat = SixLabors.ImageSharp.PixelFormats.Argb32;
+
+    [TestFixture]
+    public class RenderingTests
+    {
+        [Test]
+        [Explicit("only for manually measuring the rendering speed")]
+        public void Measure_Performance()
+        {
+            var writer = new BarcodeWriter<SelectedPixelFormat>
+            {
+                Format = BarcodeFormat.AZTEC,
+                Options = new ZXing.Aztec.AztecEncodingOptions
+                {
+                    Width = 1000,
+                    Height = 1000
+                }
+            };
+            var stopWatch = new System.Diagnostics.Stopwatch();
+
+            stopWatch.Restart();
+            var bmp1 = writer.Write("123456789012");
+            stopWatch.Stop();
+            Assert.That(bmp1, Is.Not.Null);
+            Console.WriteLine(stopWatch.Elapsed);
+
+            stopWatch.Restart();
+            var bmp2 = writer.Write("123456789012");
+            stopWatch.Stop();
+            Assert.That(bmp2, Is.Not.Null);
+            Console.WriteLine(stopWatch.Elapsed);
+
+            var image = writer.Write("123456789012");
+            using (var fileStream = System.IO.File.Create("test.png"))
+            {
+                image.Save(fileStream, new SixLabors.ImageSharp.Formats.Png.PngEncoder());
+            }
+        }
+
+        [TestCase(BarcodeFormat.AZTEC, "123456789012")]
+        [TestCase(BarcodeFormat.CODE_128, "N-c9fc4114210805000022")]
+        public void Roundtrip_Test(BarcodeFormat format, string content)
+        {
+            var writer = new BarcodeWriter<SelectedPixelFormat>
+            {
+                Format = format,
+                Options = new Common.EncodingOptions
+                {
+                    Width = 1000,
+                    Height = 1000
+                }
+            };
+            var image = writer.Write(content);
+            using (var fileStream = System.IO.File.Create(content + ".png"))
+            {
+                image.Save(fileStream, new SixLabors.ImageSharp.Formats.Png.PngEncoder());
+            }
+
+            var reader = new BarcodeReader<SelectedPixelFormat>()
+            {
+                Options = new Common.DecodingOptions
+                {
+                    PureBarcode = true
+                }
+            };
+            var decodingResult = reader.Decode(image);
+
+            Assert.That(decodingResult?.Text, Is.Not.Null);
+            Assert.That(decodingResult?.Text, Is.EqualTo(content));
+        }
+    }
+}

--- a/Source/Bindings/Tests/ZXing.ImageSharp.V4/ZXing.ImageSharp.V4.Test.csproj
+++ b/Source/Bindings/Tests/ZXing.ImageSharp.V4/ZXing.ImageSharp.V4.Test.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <RootNamespace>ZXing.ImageSharp.Test</RootNamespace>
+    <AssemblyName>ZXing.ImageSharp.V4.Test</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <SixLaborsLicenseKey>$(SIXLABORS_LICENSE_KEY)</SixLaborsLicenseKey>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.10" />
+    <PackageReference Include="ZXing.Net" Version="0.16.11" />
+    <PackageReference Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.14" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ZXing.ImageSharp.V4\ZXing.ImageSharp.V4.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Bindings/ZXing.ImageSharp.V4/BarcodeReader.Extensions.cs
+++ b/Source/Bindings/ZXing.ImageSharp.V4/BarcodeReader.Extensions.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 ZXing.Net authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using ZXing.ImageSharp;
+
+namespace ZXing
+{
+    /// <summary>
+    /// extensions methods which are working directly on any IBarcodeReaderGeneric implementation
+    /// </summary>
+    public static class BarcodeReaderExtensions
+    {
+        /// <summary>
+        /// uses the IBarcodeReaderGeneric implementation and the <see cref="ImageSharpLuminanceSource{TPixel}"/> class for decoding
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="image"></param>
+        /// <returns></returns>
+        public static Result Decode<TPixel>(this IBarcodeReaderGeneric reader, Image<TPixel> image) where TPixel : unmanaged, IPixel<TPixel>
+        {
+            var luminanceSource = new ImageSharpLuminanceSource<TPixel>(image);
+            return reader.Decode(luminanceSource);
+        }
+
+        /// <summary>
+        /// uses the IBarcodeReaderGeneric implementation and the <see cref="ImageSharpLuminanceSource{TPixel}"/> class for decoding
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="image"></param>
+        /// <returns></returns>
+        public static Result[] DecodeMultiple<TPixel>(this IBarcodeReaderGeneric reader, Image<TPixel> image) where TPixel : unmanaged, IPixel<TPixel>
+        {
+            var luminanceSource = new ImageSharpLuminanceSource<TPixel>(image);
+            return reader.DecodeMultiple(luminanceSource);
+        }
+    }
+}

--- a/Source/Bindings/ZXing.ImageSharp.V4/BarcodeReader.cs
+++ b/Source/Bindings/ZXing.ImageSharp.V4/BarcodeReader.cs
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 ZXing.Net authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace ZXing.ImageSharp
+{
+    /// <summary>
+    /// specific implementation of a barcode reader which can be used with ImageSharp ImageBase objects
+    /// </summary>
+    public class BarcodeReader<TPixel> : ZXing.BarcodeReader<Image<TPixel>> where TPixel : unmanaged, IPixel<TPixel>
+    {
+        private static readonly System.Func<Image<TPixel>, LuminanceSource> defaultCreateLuminanceSource =
+           (bitmap) => new ImageSharpLuminanceSource<TPixel>(bitmap);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BarcodeReader{TPixel}"/> class.
+        /// </summary>
+        public BarcodeReader()
+           : this(null, defaultCreateLuminanceSource, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BarcodeReader{TPixel}"/> class.
+        /// </summary>
+        /// <param name="reader">Sets the reader which should be used to find and decode the barcode.
+        /// If null then MultiFormatReader is used</param>
+        /// <param name="createLuminanceSource">Sets the function to create a luminance source object for a bitmap.
+        /// If null, an exception is thrown when Decode is called</param>
+        /// <param name="createBinarizer">Sets the function to create a binarizer object for a luminance source.
+        /// If null then HybridBinarizer is used</param>
+        public BarcodeReader(Reader reader,
+           System.Func<Image<TPixel>, LuminanceSource> createLuminanceSource,
+           System.Func<LuminanceSource, Binarizer> createBinarizer)
+           : base(reader, createLuminanceSource ?? defaultCreateLuminanceSource, createBinarizer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BarcodeReader{TPixel}"/> class.
+        /// </summary>
+        /// <param name="reader">Sets the reader which should be used to find and decode the barcode.
+        /// If null then MultiFormatReader is used</param>
+        /// <param name="createLuminanceSource">Sets the function to create a luminance source object for a bitmap.
+        /// If null, an exception is thrown when Decode is called</param>
+        /// <param name="createBinarizer">Sets the function to create a binarizer object for a luminance source.
+        /// If null then HybridBinarizer is used</param>
+        /// <param name="createRGBLuminanceSource">Sets the function to create a luminance source object for a rgb raw byte array.</param>
+        public BarcodeReader(Reader reader,
+           System.Func<Image<TPixel>, LuminanceSource> createLuminanceSource,
+           System.Func<LuminanceSource, Binarizer> createBinarizer,
+           System.Func<byte[], int, int, RGBLuminanceSource.BitmapFormat, LuminanceSource> createRGBLuminanceSource)
+           : base(reader, createLuminanceSource ?? defaultCreateLuminanceSource, createBinarizer, createRGBLuminanceSource)
+        {
+        }
+    }
+}

--- a/Source/Bindings/ZXing.ImageSharp.V4/BarcodeWriter.Extensions.cs
+++ b/Source/Bindings/ZXing.ImageSharp.V4/BarcodeWriter.Extensions.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 ZXing.Net authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using ZXing.ImageSharp.Rendering;
+
+namespace ZXing
+{
+    /// <summary>
+    /// extensions methods which are working directly on any BarcodeWriterGeneric implementation
+    /// </summary>
+    public static class BarcodeWriterExtensions
+    {
+        /// <summary>
+        /// uses the BarcodeWriterGeneric implementation and the <see cref="ImageSharpRenderer{TPixel}"/> class for decoding
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="content"></param>
+        /// <returns></returns>
+        public static Image<TPixel> WriteAsImageSharp<TPixel>(this IBarcodeWriterGeneric writer, string content) where TPixel : unmanaged, IPixel<TPixel>
+        {
+            var bitmatrix = writer.Encode(content);
+            var renderer = new ImageSharpRenderer<TPixel>();
+            return renderer.Render(bitmatrix, writer.Format, content, writer.Options);
+        }
+    }
+}

--- a/Source/Bindings/ZXing.ImageSharp.V4/BarcodeWriter.cs
+++ b/Source/Bindings/ZXing.ImageSharp.V4/BarcodeWriter.cs
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 ZXing.Net authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using ZXing.ImageSharp.Rendering;
+
+namespace ZXing.ImageSharp
+{
+    /// <summary>
+    /// barcode writer which creates ImageSharp Image instances
+    /// </summary>
+    public class BarcodeWriter<TPixel> : ZXing.BarcodeWriter<Image<TPixel>> where TPixel : unmanaged, IPixel<TPixel>
+    {
+        /// <summary>
+        /// contructor
+        /// </summary>
+        public BarcodeWriter()
+        {
+            Renderer = new ImageSharpRenderer<TPixel>();
+        }
+    }
+}

--- a/Source/Bindings/ZXing.ImageSharp.V4/ImageSharpLuminanceSource.cs
+++ b/Source/Bindings/ZXing.ImageSharp.V4/ImageSharpLuminanceSource.cs
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 ZXing.Net authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace ZXing.ImageSharp
+{
+    using SixLabors.ImageSharp;
+    using SixLabors.ImageSharp.PixelFormats;
+
+    /// <summary>
+    /// specific implementation of a luminance source which can be used with ImageSharp Image objects
+    /// </summary>
+    public class ImageSharpLuminanceSource<TPixel> : BaseLuminanceSource where TPixel : unmanaged, IPixel<TPixel>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageSharpLuminanceSource{TPixel}"/> class.
+        /// </summary>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        protected ImageSharpLuminanceSource(int width, int height)
+           : base(width, height)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageSharpLuminanceSource{TPixel}"/> class
+        /// with the image of a Bitmap instance
+        /// </summary>
+        /// <param name="bitmap">The bitmap.</param>
+        public ImageSharpLuminanceSource(Image<TPixel> bitmap)
+           : base(bitmap.Width, bitmap.Height)
+        {
+            var height = bitmap.Height;
+            var width = bitmap.Width;
+
+            // In order to measure pure decoding speed, we convert the entire image to a greyscale array
+            // The underlying raster of image consists of bytes with the luminance values
+            var luminanceIndex = 0;
+
+            bitmap.ProcessPixelRows(accessor =>
+            {
+                for (int y = 0; y < accessor.Height; y++)
+                {
+                    System.Span<TPixel> pixelRow = accessor.GetRowSpan(y);
+
+                    for (int x = 0; x < pixelRow.Length; x++)
+                    {
+                        var pixelRgba32 = pixelRow[x].ToRgba32();
+
+                        var luminance = (byte)((BChannelWeight * pixelRgba32.B +
+                                                 GChannelWeight * pixelRgba32.G +
+                                                 RChannelWeight * pixelRgba32.R) >> ChannelWeight);
+
+                        // calculating the resulting luminance based upon a white background
+                        var alpha = pixelRgba32.A;
+                        luminance = (byte)(((luminance * alpha) >> 8) + (255 * (255 - alpha) >> 8) + 1);
+                        luminances[luminanceIndex] = luminance;
+                        luminanceIndex++;
+                    }
+                }
+            });
+        }
+
+        /// <summary>
+        /// Should create a new luminance source with the right class type.
+        /// The method is used in methods crop and rotate.
+        /// </summary>
+        /// <param name="newLuminances">The new luminances.</param>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        /// <returns></returns>
+        protected override LuminanceSource CreateLuminanceSource(byte[] newLuminances, int width, int height)
+        {
+            return new ImageSharpLuminanceSource<TPixel>(width, height) { luminances = newLuminances };
+        }
+    }
+}

--- a/Source/Bindings/ZXing.ImageSharp.V4/Properties/AssemblyInfo.cs
+++ b/Source/Bindings/ZXing.ImageSharp.V4/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyCompany("ZXing.Net Development")]
+[assembly: AssemblyProduct("ZXing.ImageSharp.V4")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCopyright("Copyright \u00A9 2026")]
+[assembly: AssemblyDescription("ZXing.Net Bindings to ImageSharp 4.x")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a4c8e2f1-9b3d-4e7a-8c5f-1d2e3f4a5b6c")]

--- a/Source/Bindings/ZXing.ImageSharp.V4/Rendering/ImageSharpRenderer.cs
+++ b/Source/Bindings/ZXing.ImageSharp.V4/Rendering/ImageSharpRenderer.cs
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017 ZXing.Net authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+using ZXing.Common;
+
+namespace ZXing.ImageSharp.Rendering
+{
+    /// <summary>
+    /// IBarcodeRenderer implementation which creates an ImageSharp Image object from the barcode BitMatrix
+    /// </summary>
+    public class ImageSharpRenderer<TPixel> : ZXing.Rendering.IBarcodeRenderer<Image<TPixel>> where TPixel : unmanaged, IPixel<TPixel>
+    {
+        /// <summary>
+        /// Gets or sets the foreground color.
+        /// </summary>
+        /// <value>The foreground color.</value>
+        public Color Foreground { get; set; }
+
+        /// <summary>
+        /// Gets or sets the background color.
+        /// </summary>
+        /// <value>The background color.</value>
+        public Color Background { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageSharpRenderer{TPixel}"/> class.
+        /// </summary>
+        public ImageSharpRenderer()
+        {
+            Foreground = Color.Black;
+            Background = Color.White;
+        }
+
+        /// <summary>
+        /// renders the image
+        /// </summary>
+        /// <param name="matrix"></param>
+        /// <param name="format"></param>
+        /// <param name="content"></param>
+        /// <returns></returns>
+        public Image<TPixel> Render(BitMatrix matrix, BarcodeFormat format, string content)
+        {
+            return Render(matrix, format, content, new EncodingOptions());
+        }
+
+        /// <summary>
+        /// renders the image
+        /// </summary>
+        /// <param name="matrix"></param>
+        /// <param name="format"></param>
+        /// <param name="content"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        virtual public Image<TPixel> Render(BitMatrix matrix, BarcodeFormat format, string content, EncodingOptions options)
+        {
+            var width = matrix.Width;
+            var height = matrix.Height;
+            var foreColor = Foreground;
+            var backColor = Background;
+
+            var pixelsize = 1;
+
+            if (options != null)
+            {
+                if (options.Width > width)
+                {
+                    width = options.Width;
+                }
+                if (options.Height > height)
+                {
+                    height = options.Height;
+                }
+                // calculating the scaling factor
+                pixelsize = width / matrix.Width;
+                if (pixelsize > height / matrix.Height)
+                {
+                    pixelsize = height / matrix.Height;
+                }
+            }
+
+            var result = new Image<TPixel>(width, height);
+            for (int y = 0; y < matrix.Height; y++)
+            {
+                for (var pixelsizeHeight = 0; pixelsizeHeight < pixelsize; pixelsizeHeight++)
+                {
+                    var rowOffset = pixelsize * y + pixelsizeHeight;
+
+                    for (var x = 0; x < matrix.Width; x++)
+                    {
+                        var color = matrix[x, y] ? foreColor : backColor;
+                        for (var pixelsizeWidth = 0; pixelsizeWidth < pixelsize; pixelsizeWidth++)
+                        {
+                            result[pixelsize * x + pixelsizeWidth, rowOffset] = color.ToPixel<TPixel>();
+                        }
+                    }
+                    for (var x = pixelsize * matrix.Width; x < width; x++)
+                    {
+                        result[x, rowOffset] = backColor.ToPixel<TPixel>();
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Source/Bindings/ZXing.ImageSharp.V4/ZXing.ImageSharp.V4.csproj
+++ b/Source/Bindings/ZXing.ImageSharp.V4/ZXing.ImageSharp.V4.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <VersionPrefix>0.16.18</VersionPrefix>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+    <PlatformTarget>anycpu</PlatformTarget>
+    <DebugType>portable</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>ZXing.ImageSharp.V4</AssemblyName>
+    <PackageId>ZXing.Net.Bindings.ImageSharp.V4</PackageId>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../../Key/private.snk</AssemblyOriginatorKeyFile>
+    <SixLaborsLicenseKey>$(SIXLABORS_LICENSE_KEY)</SixLaborsLicenseKey>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rendering\ImageSharpRenderer.cs" />
+    <Compile Include="ImageSharpLuminanceSource.cs" />
+    <Compile Include="BarcodeWriter.Extensions.cs" />
+    <Compile Include="BarcodeWriter.cs" />
+    <Compile Include="BarcodeReader.cs" />
+    <Compile Include="BarcodeReader.Extensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0" />
+    <PackageReference Include="ZXing.Net" Version="0.16.11" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Bindings/ZXing.ImageSharp.V4/global.json
+++ b/Source/Bindings/ZXing.ImageSharp.V4/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/Source/Bindings/ZXing.ImageSharp.V4/nuget-pack.cmd
+++ b/Source/Bindings/ZXing.ImageSharp.V4/nuget-pack.cmd
@@ -1,0 +1,6 @@
+@ECHO OFF
+
+SET OUTDIR=..\..\..\Build\Deployment
+mkdir %OUTDIR%
+
+..\..\..\3rdParty\nuget\nuget pack project.nuspec -outputdirectory %OUTDIR%

--- a/Source/Bindings/ZXing.ImageSharp.V4/project.nuspec
+++ b/Source/Bindings/ZXing.ImageSharp.V4/project.nuspec
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <version>0.16.18</version>
+    <authors>Michael Jahn</authors>
+    <owners>Michael Jahn</owners>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://github.com/micjahn/ZXing.Net/</projectUrl>
+    <icon>logo.jpg</icon>
+    <id>ZXing.Net.Bindings.ImageSharp.V4</id>
+    <title>ZXing.Net.Bindings.ImageSharp.V4</title>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>ZXing.Net Bindings for ImageSharp - use ImageSharp 4.0 with ZXing.Net for barcode reading</description>
+    <readme>readme.md</readme>
+    <summary>ZXing.Net Bindings for SixLabors.ImageSharp</summary>
+    <releaseNotes></releaseNotes>
+    <tags>ZXing ImageSharp</tags>
+    <repository type="git" url="https://github.com/micjahn/ZXing.Net/" />
+    <dependencies>
+      <group targetFramework="net8.0">
+        <dependency id="ZXing.Net" version="0.16.11.0" exclude="Build,Analyzers" />
+        <dependency id="SixLabors.ImageSharp" version="4.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net10.0">
+        <dependency id="ZXing.Net" version="0.16.11.0" exclude="Build,Analyzers" />
+        <dependency id="SixLabors.ImageSharp" version="4.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\..\..\Icons\logo.jpg" target="." />
+    <file src="readme.md" target="." />
+    <file src="bin\Release\net8.0\ZXing.ImageSharp.V4.dll" target="lib\net8.0\ZXing.ImageSharp.V4.dll" />
+    <file src="bin\Release\net8.0\ZXing.ImageSharp.V4.pdb" target="lib\net8.0\ZXing.ImageSharp.V4.pdb" />
+    <file src="bin\Release\net8.0\ZXing.ImageSharp.V4.xml" target="lib\net8.0\ZXing.ImageSharp.V4.xml" />
+    <file src="bin\Release\net10.0\ZXing.ImageSharp.V4.dll" target="lib\net10.0\ZXing.ImageSharp.V4.dll" />
+    <file src="bin\Release\net10.0\ZXing.ImageSharp.V4.pdb" target="lib\net10.0\ZXing.ImageSharp.V4.pdb" />
+    <file src="bin\Release\net10.0\ZXing.ImageSharp.V4.xml" target="lib\net10.0\ZXing.ImageSharp.V4.xml" />
+  </files>
+</package>

--- a/Source/Bindings/ZXing.ImageSharp.V4/readme.md
+++ b/Source/Bindings/ZXing.ImageSharp.V4/readme.md
@@ -1,0 +1,5 @@
+# ZXing.Net.Bindings.ImageSharp.V4
+
+ZXing.Net Bindings for ImageSharp - use ImageSharp 4.0 with ZXing.Net for barcode reading
+
+This package contains specific implementations of barcode reader and writer classes which are using types from the ImageSharp library.

--- a/build_deployment_copy_operations.bindings.txt
+++ b/build_deployment_copy_operations.bindings.txt
@@ -49,6 +49,12 @@
 %CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V3\bin\Release\net6.0\zxing.imagesharp.V3.dll %BINARY_DIR%\Bindings\ImageSharp.V3\net6.0\
 %CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V3\bin\Release\net6.0\zxing.imagesharp.V3.pdb %BINARY_DIR%\Bindings\ImageSharp.V3\net6.0\
 %CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V3\bin\Release\net6.0\zxing.imagesharp.V3.xml %BINARY_DIR%\Bindings\ImageSharp.V3\net6.0\
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net8.0\zxing.imagesharp.V4.dll %BINARY_DIR%\Bindings\ImageSharp.V4\net8.0\
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net8.0\zxing.imagesharp.V4.pdb %BINARY_DIR%\Bindings\ImageSharp.V4\net8.0\
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net8.0\zxing.imagesharp.V4.xml %BINARY_DIR%\Bindings\ImageSharp.V4\net8.0\
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net10.0\zxing.imagesharp.V4.dll %BINARY_DIR%\Bindings\ImageSharp.V4\net10.0\
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net10.0\zxing.imagesharp.V4.pdb %BINARY_DIR%\Bindings\ImageSharp.V4\net10.0\
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net10.0\zxing.imagesharp.V4.xml %BINARY_DIR%\Bindings\ImageSharp.V4\net10.0\
 %CURRENT_DIR%\Source\Bindings\ZXing.Magick\bin\Release\netstandard2.0\zxing.magick.dll %BINARY_DIR%\Bindings\Magick\netstandard2.0\
 %CURRENT_DIR%\Source\Bindings\ZXing.Magick\bin\Release\netstandard2.0\zxing.magick.pdb %BINARY_DIR%\Bindings\Magick\netstandard2.0\
 %CURRENT_DIR%\Source\Bindings\ZXing.Magick\bin\Release\netstandard2.0\zxing.magick.xml %BINARY_DIR%\Bindings\Magick\netstandard2.0\

--- a/build_deployment_files.bindings.txt
+++ b/build_deployment_files.bindings.txt
@@ -16,6 +16,8 @@
 %CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V2\bin\Release\netstandard2.0\zxing.imagesharp.V2.dll
 %CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V2\bin\Release\netstandard2.1\zxing.imagesharp.V2.dll
 %CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V3\bin\Release\net6.0\zxing.imagesharp.V3.dll
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net8.0\zxing.imagesharp.V4.dll
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net10.0\zxing.imagesharp.V4.dll
 %BINARY_DIR%\Bindings\kinect\V1\zxing.kinect.dll
 %BINARY_DIR%\Bindings\kinect\V2\zxing.kinect.dll
 %CURRENT_DIR%\Source\Bindings\ZXing.Magick\bin\Release\netstandard2.0\zxing.magick.dll

--- a/build_deployment_strong_named_files.bindings.txt
+++ b/build_deployment_strong_named_files.bindings.txt
@@ -13,6 +13,8 @@
 %CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V2\bin\Release\netstandard2.0\ZXing.ImageSharp.V2.dll
 %CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V2\bin\Release\netstandard2.1\ZXing.ImageSharp.V2.dll
 %CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V3\bin\Release\net6.0\ZXing.ImageSharp.V3.dll
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net8.0\ZXing.ImageSharp.V4.dll
+%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\bin\Release\net10.0\ZXing.ImageSharp.V4.dll
 %BINARY_DIR%\Bindings\kinect\V1\zxing.kinect.dll
 %BINARY_DIR%\Bindings\kinect\V2\zxing.kinect.dll
 %CURRENT_DIR%\Source\Bindings\ZXing.Magick\bin\Release\netstandard2.0\ZXing.Magick.dll

--- a/nuget-pack.bindings.cmd
+++ b/nuget-pack.bindings.cmd
@@ -14,6 +14,10 @@ CD "%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp\"
 CALL nuget-pack.cmd
 CD "%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V2\"
 CALL nuget-pack.cmd
+CD "%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V3\"
+CALL nuget-pack.cmd
+CD "%CURRENT_DIR%\Source\Bindings\ZXing.ImageSharp.V4\"
+CALL nuget-pack.cmd
 CD "%CURRENT_DIR%\Source\Bindings\ZXing.Kinect\"
 CALL nuget-pack.cmd
 CD "%CURRENT_DIR%\Source\Bindings\ZXing.Magick\"

--- a/zxing.vs2022.ci.sln
+++ b/zxing.vs2022.ci.sln
@@ -142,6 +142,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.EmguCV", "Source\Bind
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZXing.ImageSharp.Test", "Source\Bindings\Tests\ZXing.ImageSharp\ZXing.ImageSharp.Test.csproj", "{861AD178-2F4D-4E95-B37B-ACCF768C82D9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.ImageSharp.V4.Test", "Source\Bindings\Tests\ZXing.ImageSharp.V4\ZXing.ImageSharp.V4.Test.csproj", "{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}"
+EndProject
 Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "zxing.net4.7.doc", "Source\lib\documentation\zxing.net4.7.doc.shfbproj", "{4782824C-DD85-427B-8102-70A87C1A7DE0}"
 EndProject
 Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "zxing.net4.8.doc", "Source\lib\documentation\zxing.net4.8.doc.shfbproj", "{2C6DE13F-8129-453A-9BB5-997077EAE269}"
@@ -153,6 +155,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.ImageSharp.V2", "Source\Bindings\ZXing.ImageSharp.V2\ZXing.ImageSharp.V2.csproj", "{AB205F83-41E0-4ED1-B4F8-6F7994F7DFFC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.ImageSharp.V3", "Source\Bindings\ZXing.ImageSharp.V3\ZXing.ImageSharp.V3.csproj", "{B6B088CA-F454-41B9-B36F-8E59F91DFBFE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.ImageSharp.V4", "Source\Bindings\ZXing.ImageSharp.V4\ZXing.ImageSharp.V4.csproj", "{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1272,6 +1276,55 @@ Global
 		{B6B088CA-F454-41B9-B36F-8E59F91DFBFE}.Release|x64.Build.0 = Release|Any CPU
 		{B6B088CA-F454-41B9-B36F-8E59F91DFBFE}.Release|x86.ActiveCfg = Release|Any CPU
 		{B6B088CA-F454-41B9-B36F-8E59F91DFBFE}.Release|x86.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|Any CPU.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|ARM.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|ARM.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|x64.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|x64.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|x86.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|x86.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|x86.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|Any CPU.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|Any CPU.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|ARM.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|ARM.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|x64.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|x64.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|x86.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|x86.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|ARM.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|x64.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|x86.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|ARM.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|x64.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|x86.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|Any CPU.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|Any CPU.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|ARM.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|x64.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|x86.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1317,6 +1370,8 @@ Global
 		{3E1FFA98-B3E1-47F6-AB50-3EC4FB7E710C} = {369FB285-4E6C-428A-9CC3-45FC75ECDFC1}
 		{AB205F83-41E0-4ED1-B4F8-6F7994F7DFFC} = {E3647B3A-B903-402A-B7F7-711A4A1512B9}
 		{B6B088CA-F454-41B9-B36F-8E59F91DFBFE} = {E3647B3A-B903-402A-B7F7-711A4A1512B9}
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D} = {E3647B3A-B903-402A-B7F7-711A4A1512B9}
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B} = {369FB285-4E6C-428A-9CC3-45FC75ECDFC1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73A9B453-AE71-4A98-B68A-2389573CD311}

--- a/zxing.vs2022.sln
+++ b/zxing.vs2022.sln
@@ -142,6 +142,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.EmguCV", "Source\Bind
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZXing.ImageSharp.Test", "Source\Bindings\Tests\ZXing.ImageSharp\ZXing.ImageSharp.Test.csproj", "{861AD178-2F4D-4E95-B37B-ACCF768C82D9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.ImageSharp.V4.Test", "Source\Bindings\Tests\ZXing.ImageSharp.V4\ZXing.ImageSharp.V4.Test.csproj", "{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}"
+EndProject
 Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "zxing.net4.7.doc", "Source\lib\documentation\zxing.net4.7.doc.shfbproj", "{4782824C-DD85-427B-8102-70A87C1A7DE0}"
 EndProject
 Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "zxing.net4.8.doc", "Source\lib\documentation\zxing.net4.8.doc.shfbproj", "{2C6DE13F-8129-453A-9BB5-997077EAE269}"
@@ -153,6 +155,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.ImageSharp.V2", "Source\Bindings\ZXing.ImageSharp.V2\ZXing.ImageSharp.V2.csproj", "{CED0DDBB-E431-476A-BFED-F6AFF0D2CC8A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.ImageSharp.V3", "Source\Bindings\ZXing.ImageSharp.V3\ZXing.ImageSharp.V3.csproj", "{B6B088CA-F454-41B9-B36F-8E59F91DFBFE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.ImageSharp.V4", "Source\Bindings\ZXing.ImageSharp.V4\ZXing.ImageSharp.V4.csproj", "{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZXing.SkiaSharp.V2", "Source\Bindings\ZXing.SkiaSharp.V2\ZXing.SkiaSharp.V2.csproj", "{9DD75687-B4C5-4398-8478-9B56595282C1}"
 EndProject
@@ -1735,6 +1739,69 @@ Global
 		{B6B088CA-F454-41B9-B36F-8E59F91DFBFE}.Release|x64.Build.0 = Release|Any CPU
 		{B6B088CA-F454-41B9-B36F-8E59F91DFBFE}.Release|x86.ActiveCfg = Release|Any CPU
 		{B6B088CA-F454-41B9-B36F-8E59F91DFBFE}.Release|x86.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|Any CPU.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|ARM.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|ARM.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|x64.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|x64.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|x86.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug - Reduced|x86.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Debug|x86.Build.0 = Debug|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|Any CPU.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|Any CPU.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|ARM.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|ARM.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|x64.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|x64.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|x86.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release with Documentation|x86.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|ARM.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|x64.Build.0 = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D}.Release|x86.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|ARM.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|ARM.Build.0 = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|x64.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|x64.Build.0 = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|x86.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug - Reduced|x86.Build.0 = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|Any CPU.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|Any CPU.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|ARM.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|ARM.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|x64.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|x64.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|x86.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release with Documentation|x86.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|ARM.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|x64.Build.0 = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B}.Release|x86.Build.0 = Release|Any CPU
 		{9DD75687-B4C5-4398-8478-9B56595282C1}.Debug - Reduced|Any CPU.ActiveCfg = Debug|Any CPU
 		{9DD75687-B4C5-4398-8478-9B56595282C1}.Debug - Reduced|Any CPU.Build.0 = Debug|Any CPU
 		{9DD75687-B4C5-4398-8478-9B56595282C1}.Debug - Reduced|ARM.ActiveCfg = Debug|Any CPU
@@ -1812,6 +1879,8 @@ Global
 		{3E1FFA98-B3E1-47F6-AB50-3EC4FB7E710C} = {369FB285-4E6C-428A-9CC3-45FC75ECDFC1}
 		{CED0DDBB-E431-476A-BFED-F6AFF0D2CC8A} = {E3647B3A-B903-402A-B7F7-711A4A1512B9}
 		{B6B088CA-F454-41B9-B36F-8E59F91DFBFE} = {E3647B3A-B903-402A-B7F7-711A4A1512B9}
+		{7E2A9C4D-1F8B-4E6A-9D3C-5B7E8F9A0C1D} = {E3647B3A-B903-402A-B7F7-711A4A1512B9}
+		{F3D8B2E1-6A4C-4D9F-8E7B-2C1D5A9E4F6B} = {369FB285-4E6C-428A-9CC3-45FC75ECDFC1}
 		{9DD75687-B4C5-4398-8478-9B56595282C1} = {E3647B3A-B903-402A-B7F7-711A4A1512B9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution


### PR DESCRIPTION
Introduce a new binding package for ImageSharp 4.x, following the existing V3 binding structure while adapting to ImageSharp 4 breaking pixel API changes and .NET 8+ requirements.

Binding changes:
- Add ZXing.ImageSharp.V4 targeting net8.0 and net10.0
- Depend on SixLabors.ImageSharp 4.0.0 and ZXing.Net 0.16.11
- Update luminance conversion to use IPixel.ToRgba32() return value
- Update rendering to use Color.ToPixel<TPixel>() instead of FromRgba32
- Configure SixLaborsLicenseKey from SIXLABORS_LICENSE_KEY for ImageSharp 4 build-time license enforcement
- Add NuGet packaging (project.nuspec, nuget-pack.cmd, readme) and SDK pin via global.json

Test coverage:
- Add ZXing.ImageSharp.V4.Test for net8.0 and net10.0
- Port luminance accuracy and barcode roundtrip tests from the V1 suite
- Compare ImageSharp luminance output against BitmapLuminanceSource
- Add robust test-data path resolution for SDK-style test output layout

Build and solution integration:
- Register binding and test projects in zxing.vs2022.sln and zxing.vs2022.ci.sln
- Add net8.0/net10.0 deployment entries to binding deployment scripts
- Include ImageSharp V3 and V4 in nuget-pack.bindings.cmd

Note license is now required to build with image sharp, I've configured MS Build property so it will read from environment variable `SIXLABORS_LICENSE_KEY`, community license can be requested at https://licensing.sixlabors.com/ ( Info about licensing https://docs.sixlabors.com/articles/imagesharp/?tabs=tabid-1 )