### PR TITLE
Add Data Matrix Rectangular Extension (DMRE) support as encoding option

### DIFF
--- a/Source/interop/Encoding/DatamatrixEncodingOptions.cs
+++ b/Source/interop/Encoding/DatamatrixEncodingOptions.cs
@@ -125,6 +125,16 @@ namespace ZXing.Interop.Encoding
         }
 
         /// <summary>
+        /// Specifies whether to enable Data Matrix Rectangular Extension (DMRE) symbol selection.
+        /// DMRE symbols are never selected unless this option is explicitly enabled.
+        /// </summary>
+        public bool EnableDMRE
+        {
+            get { return wrappedDatamatrixEncodingOptions.EnableDMRE; }
+            set { wrappedDatamatrixEncodingOptions.EnableDMRE = value; }
+        }
+
+        /// <summary>
         /// Specifies what character encoding to use where applicable (type {@link String})
         /// </summary>
         public string CharacterSet

--- a/Source/lib/EncodeHintType.cs
+++ b/Source/lib/EncodeHintType.cs
@@ -215,6 +215,13 @@ namespace ZXing
         DATA_MATRIX_COMPACT,
 
         /// <summary>
+        /// Whether to enable Data Matrix Rectangular Extension (DMRE) symbol selection.
+        /// type: <see cref="System.Boolean" />, or "true" or "false"
+        /// DMRE symbols are never selected unless this hint is explicitly enabled.
+        /// </summary>
+        DATA_MATRIX_DMRE,
+
+        /// <summary>
         /// Specifies whether to use compact mode for Code-128 code (type {@link Boolean}, or "true" or "false"
         /// This can yield slightly smaller bar codes. This option and {@link #FORCE_CODE_SET} are mutually
         /// exclusive options.

--- a/Source/lib/datamatrix/DataMatrixWriter.cs
+++ b/Source/lib/datamatrix/DataMatrixWriter.cs
@@ -77,6 +77,7 @@ namespace ZXing.Datamatrix
             var noPadding = false;
             System.Text.Encoding encoding = null;
             var disableEci = false;
+            var allowDMRE = false;
             if (hints != null)
             {
                 if (hints.ContainsKey(EncodeHintType.DATA_MATRIX_SHAPE))
@@ -130,6 +131,7 @@ namespace ZXing.Datamatrix
                 }
                 encoding = IDictionaryExtensions.GetEncoding(hints, null);
                 disableEci = IDictionaryExtensions.IsBooleanFlagSet(hints, EncodeHintType.DISABLE_ECI, disableEci);
+                allowDMRE = IDictionaryExtensions.IsBooleanFlagSet(hints, EncodeHintType.DATA_MATRIX_DMRE, allowDMRE);
             }
 
             //1. step: Data encodation
@@ -144,10 +146,10 @@ namespace ZXing.Datamatrix
             else
             {
                 var hasForceC40Hint = IDictionaryExtensions.IsBooleanFlagSet(hints, EncodeHintType.FORCE_C40);
-                encoded = HighLevelEncoder.encodeHighLevel(contents, shape, minSize, maxSize, defaultEncodation, hasForceC40Hint, encoding, disableEci);
+                encoded = HighLevelEncoder.encodeHighLevel(contents, shape, minSize, maxSize, defaultEncodation, hasForceC40Hint, encoding, disableEci, allowDMRE);
             }
 
-            SymbolInfo symbolInfo = SymbolInfo.lookup(encoded.Length, shape, minSize, maxSize, true);
+            SymbolInfo symbolInfo = SymbolInfo.lookup(encoded.Length, shape, minSize, maxSize, true, allowDMRE);
 
             //2. step: ECC generation
             String codewords = ErrorCorrection.encodeECC200(encoded, symbolInfo);

--- a/Source/lib/datamatrix/encoder/DatamatrixEncodingOptions.cs
+++ b/Source/lib/datamatrix/encoder/DatamatrixEncodingOptions.cs
@@ -205,6 +205,39 @@ namespace ZXing.Datamatrix
         }
 
         /// <summary>
+        /// Specifies whether to enable Data Matrix Rectangular Extension (DMRE) symbol selection.
+        /// DMRE symbols are never selected unless this option is explicitly enabled.
+        /// </summary>
+#if !NETSTANDARD && !NETFX_CORE && !PORTABLE && !UNITY
+        [CategoryAttribute("Standard"), DescriptionAttribute("Specifies whether to enable Data Matrix Rectangular Extension (DMRE) symbol selection.")]
+#endif
+        public bool EnableDMRE
+        {
+            get
+            {
+                if (Hints.ContainsKey(EncodeHintType.DATA_MATRIX_DMRE))
+                {
+                    var boolObj = Hints[EncodeHintType.DATA_MATRIX_DMRE];
+                    if (boolObj != null)
+                        return (bool)boolObj;
+                }
+                return false;
+            }
+            set
+            {
+                if (value)
+                {
+                    Hints[EncodeHintType.DATA_MATRIX_DMRE] = value;
+                }
+                else
+                {
+                    if (Hints.ContainsKey(EncodeHintType.DATA_MATRIX_DMRE))
+                        Hints.Remove(EncodeHintType.DATA_MATRIX_DMRE);
+                }
+            }
+        }
+
+        /// <summary>
         /// Forces C40 encoding for data-matrix (type {@link Boolean}, or "true" or "false") {@link String } value). This 
         /// option and {@link #DATA_MATRIX_COMPACT} are mutually exclusive.
         /// </summary>

--- a/Source/lib/datamatrix/encoder/EncoderContext.cs
+++ b/Source/lib/datamatrix/encoder/EncoderContext.cs
@@ -26,6 +26,7 @@ namespace ZXing.Datamatrix.Encoder
         private SymbolShapeHint shape;
         private Dimension minSize;
         private Dimension maxSize;
+        private bool allowDMRE;
         private readonly StringBuilder codewords;
         private int pos;
         private int newEncoding;
@@ -82,6 +83,11 @@ namespace ZXing.Datamatrix.Encoder
         {
             this.minSize = minSize;
             this.maxSize = maxSize;
+        }
+
+        public void setAllowDMRE(bool allowDMRE)
+        {
+            this.allowDMRE = allowDMRE;
         }
 
         public void setSkipAtEnd(int count)
@@ -148,7 +154,7 @@ namespace ZXing.Datamatrix.Encoder
         {
             if (this.symbolInfo == null || len > this.symbolInfo.dataCapacity)
             {
-                this.symbolInfo = SymbolInfo.lookup(len, shape, minSize, maxSize, true);
+                this.symbolInfo = SymbolInfo.lookup(len, shape, minSize, maxSize, true, allowDMRE);
             }
         }
 

--- a/Source/lib/datamatrix/encoder/HighLevelEncoder.cs
+++ b/Source/lib/datamatrix/encoder/HighLevelEncoder.cs
@@ -115,7 +115,7 @@ namespace ZXing.Datamatrix.Encoder
         /// <returns>the encoded message (the char values range from 0 to 255)</returns>
         public static String encodeHighLevel(String msg)
         {
-            return encodeHighLevel(msg, SymbolShapeHint.FORCE_NONE, null, null, Encodation.ASCII, false, null, false);
+            return encodeHighLevel(msg, SymbolShapeHint.FORCE_NONE, null, null, Encodation.ASCII, false, null, false, false);
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace ZXing.Datamatrix.Encoder
                                              Dimension maxSize,
                                              int defaultEncodation)
         {
-            return encodeHighLevel(msg, shape, minSize, maxSize, defaultEncodation, false, null, false);
+            return encodeHighLevel(msg, shape, minSize, maxSize, defaultEncodation, false, null, false, false);
         }
 
         /// <summary>
@@ -157,6 +157,31 @@ namespace ZXing.Datamatrix.Encoder
                                              Encoding encoding,
                                              bool disableEci)
         {
+            return encodeHighLevel(msg, shape, minSize, maxSize, defaultEncodation, forceC40, encoding, disableEci, false);
+        }
+
+        /// <summary>
+        /// Performs message encoding of a DataMatrix message using the algorithm described in annex P
+        /// of ISO/IEC 16022:2000(E).
+        /// </summary>
+        /// <param name="msg">the message</param>
+        /// <param name="shape">requested shape. May be {@code SymbolShapeHint.FORCE_NONE},{@code SymbolShapeHint.FORCE_SQUARE} or {@code SymbolShapeHint.FORCE_RECTANGLE}.</param>
+        /// <param name="minSize">the minimum symbol size constraint or null for no constraint</param>
+        /// <param name="maxSize">the maximum symbol size constraint or null for no constraint</param>
+        /// <param name="defaultEncodation">encoding mode to start with</param>
+        /// <param name="forceC40">enforce C40 encoding</param>
+        /// <param name="allowDMRE">if true, DMRE symbols may be selected</param>
+        /// <returns>the encoded message (the char values range from 0 to 255)</returns>
+        public static String encodeHighLevel(String msg,
+                                             SymbolShapeHint shape,
+                                             Dimension minSize,
+                                             Dimension maxSize,
+                                             int defaultEncodation,
+                                             bool forceC40,
+                                             Encoding encoding,
+                                             bool disableEci,
+                                             bool allowDMRE)
+        {
             //the codewords 0..255 are encoded as Unicode characters
             C40Encoder c40Encoder = new C40Encoder();
             Encoder[] encoders =
@@ -168,6 +193,7 @@ namespace ZXing.Datamatrix.Encoder
             var context = new EncoderContext(msg, encoding, disableEci);
             context.setSymbolShape(shape);
             context.setSizeConstraints(minSize, maxSize);
+            context.setAllowDMRE(allowDMRE);
 
             if (msg.StartsWith(MACRO_05_HEADER) && msg.EndsWith(MACRO_TRAILER))
             {

--- a/Source/lib/datamatrix/encoder/SymbolInfo.cs
+++ b/Source/lib/datamatrix/encoder/SymbolInfo.cs
@@ -177,7 +177,7 @@ namespace ZXing.Datamatrix.Encoder
 
         private static SymbolInfo lookup(int dataCodewords, SymbolShapeHint shape, bool fail)
         {
-            return lookup(dataCodewords, shape, null, null, fail);
+            return lookup(dataCodewords, shape, null, null, fail, false);
         }
         /// <summary>
         /// 
@@ -194,9 +194,29 @@ namespace ZXing.Datamatrix.Encoder
                                         Dimension maxSize,
                                         bool fail)
         {
+            return lookup(dataCodewords, shape, minSize, maxSize, fail, false);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dataCodewords"></param>
+        /// <param name="shape"></param>
+        /// <param name="minSize"></param>
+        /// <param name="maxSize"></param>
+        /// <param name="fail"></param>
+        /// <param name="allowDMRE">if true, DMRE symbols may be selected</param>
+        /// <returns></returns>
+        public static SymbolInfo lookup(int dataCodewords,
+                                        SymbolShapeHint shape,
+                                        Dimension minSize,
+                                        Dimension maxSize,
+                                        bool fail,
+                                        bool allowDMRE)
+        {
             foreach (SymbolInfo symbol in symbols)
             {
-                if (symbol.dmre)
+                if (symbol.dmre && !allowDMRE)
                     // DMRE Symbols doesn't work in all cases
                     continue;
 

--- a/Source/test/src/datamatrix/DataMatrixWriterTestCase.cs
+++ b/Source/test/src/datamatrix/DataMatrixWriterTestCase.cs
@@ -323,7 +323,7 @@ Four score and seven our forefathers brought forth", SymbolShapeHint.FORCE_SQUAR
         [TestCase('1')]
         [TestCase('a')]
         [TestCase('A')]
-        [TestCase('€')]
+        [TestCase('ï¿½')]
         public void testCharactersForLengthUntil256RoundTrip(char character)
         {
             var writer = new BarcodeWriter
@@ -369,6 +369,134 @@ Four score and seven our forefathers brought forth", SymbolShapeHint.FORCE_SQUAR
 
             if (errors.Count > 0)
                 throw new AssertionException("not every content could be encoded and decoded");
+        }
+
+        [Test]
+        public void testDefaultDoesNotSelectDMRE()
+        {
+            // 33 digits encode to ~17 codewords (16 pairs + 1 single digit).
+            // Without DMRE and FORCE_RECTANGLE: skips rect cap=5, cap=10, cap=16 symbols,
+            // then skips DMRE 8x48 (dmre=true), lands on rect cap=22 (SymbolInfo 22x18@16x10r2 -> 36x12).
+            var content = "123456789012345678901234567890123"; // 33 digits -> 17 codewords
+            var options = new DatamatrixEncodingOptions
+            {
+                SymbolShape = SymbolShapeHint.FORCE_RECTANGLE,
+            };
+            var matrix = new DataMatrixWriter().encode(content, BarcodeFormat.DATA_MATRIX, 0, 0, options.Hints);
+            Assert.That(matrix, Is.Not.Null);
+            // Should be a standard rectangular symbol (36x12), NOT DMRE 48x8
+            Assert.That(matrix.Width, Is.EqualTo(36));
+            Assert.That(matrix.Height, Is.EqualTo(12));
+        }
+
+        [Test]
+        public void testDMREOptInSelectsDMRESymbol()
+        {
+            // Same payload, but with DMRE enabled and FORCE_RECTANGLE
+            // 33 digits -> 17 codewords, fits DMRE 8x48 (cap=18), skips rect cap=5/10/16
+            var content = "123456789012345678901234567890123"; // 33 digits -> 17 codewords
+            var options = new DatamatrixEncodingOptions
+            {
+                SymbolShape = SymbolShapeHint.FORCE_RECTANGLE,
+                EnableDMRE = true
+            };
+            var matrix = new DataMatrixWriter().encode(content, BarcodeFormat.DATA_MATRIX, 0, 0, options.Hints);
+            Assert.That(matrix, Is.Not.Null);
+            // Should select DMRE 8x48 (48x8) instead of standard 36x12
+            Assert.That(matrix.Width, Is.EqualTo(48));
+            Assert.That(matrix.Height, Is.EqualTo(8));
+        }
+
+        [Test]
+        public void testDMREExactSizeViaMinMax()
+        {
+            // Constrain to DMRE 8x48 dimensions with DMRE enabled
+            var content = "Hello";
+            var options = new DatamatrixEncodingOptions
+            {
+                MinSize = new Dimension(48, 8),
+                MaxSize = new Dimension(48, 8),
+                EnableDMRE = true
+            };
+            var matrix = new DataMatrixWriter().encode(content, BarcodeFormat.DATA_MATRIX, 0, 0, options.Hints);
+            Assert.That(matrix, Is.Not.Null);
+            Assert.That(matrix.Width, Is.EqualTo(48));
+            Assert.That(matrix.Height, Is.EqualTo(8));
+        }
+
+        [Test]
+        public void testDMREWithoutOptInFailsWithExactDMREConstraints()
+        {
+            // Same min/max constraint but without EnableDMRE - DMRE symbol is skipped
+            var content = "Hello";
+            var options = new DatamatrixEncodingOptions
+            {
+                MinSize = new Dimension(48, 8),
+                MaxSize = new Dimension(48, 8),
+                // EnableDMRE not set - defaults to false
+            };
+            // No standard symbol matches 48x8, so we expect an exception
+            Assert.Throws<ArgumentException>(() =>
+                new DataMatrixWriter().encode(content, BarcodeFormat.DATA_MATRIX, 0, 0, options.Hints));
+        }
+
+        [Test]
+        public void testDMRECapacityBoundaryExactFit()
+        {
+            // DMRE 8x48 has data capacity of 18 codewords
+            // Use a payload that encodes to exactly the capacity (18 codewords)
+            // 18 ASCII characters should need ~18 codewords in ASCII encoding
+            var content = "123456789012345678"; // 18 chars
+            var options = new DatamatrixEncodingOptions
+            {
+                EnableDMRE = true,
+                SymbolShape = SymbolShapeHint.FORCE_RECTANGLE
+            };
+            // With FORCE_RECTANGLE, 18 codewords fits exactly in DMRE 8x48 (cap=18)
+            var matrix = new DataMatrixWriter().encode(content, BarcodeFormat.DATA_MATRIX, 0, 0, options.Hints);
+            Assert.That(matrix, Is.Not.Null);
+        }
+
+        [Test]
+        public void testDMRECapacityBoundaryFallsThroughToNextSymbol()
+        {
+            // 35 digits encode to 18 digit-pair codewords? Actually:
+            // 34 digits -> 17 codewords, 35 digits -> 18 codewords.
+            // To exceed 8x48 capacity 18, use 37 digits -> 19 codewords.
+            var content = "1234567890123456789012345678901234567"; // 37 digits -> 19 codewords
+
+            var options = new DatamatrixEncodingOptions
+            {
+                EnableDMRE = true,
+                SymbolShape = SymbolShapeHint.FORCE_RECTANGLE
+            };
+
+            var matrix = new DataMatrixWriter().encode(content, BarcodeFormat.DATA_MATRIX, 0, 0, options.Hints);
+
+            Assert.That(matrix, Is.Not.Null);
+            Assert.That(matrix.Width, Is.Not.EqualTo(48));
+            Assert.That(matrix.Height, Is.Not.EqualTo(8));
+        }
+
+        [Test]
+        public void testDMREOptInRoundTrip()
+        {
+            // Round-trip encode/decode with DMRE enabled using Internal.Decoder on the raw matrix
+            var content = "123456789012345678901234567890123"; // 33 digits -> 17 codewords
+            var options = new DatamatrixEncodingOptions
+            {
+                EnableDMRE = true,
+                SymbolShape = SymbolShapeHint.FORCE_RECTANGLE
+            };
+            var writer = new DataMatrixWriter();
+            var matrix = writer.encode(content, BarcodeFormat.DATA_MATRIX, 0, 0, options.Hints);
+            Assert.That(matrix, Is.Not.Null);
+            Assert.That(matrix.Width, Is.EqualTo(48));
+            Assert.That(matrix.Height, Is.EqualTo(8));
+
+            var res = new Internal.Decoder().decode(matrix);
+            Assert.That(res, Is.Not.Null);
+            Assert.That(res.Text, Is.EqualTo(content));
         }
     }
 }

--- a/Source/test/src/datamatrix/DataMatrixWriterTestCase.cs
+++ b/Source/test/src/datamatrix/DataMatrixWriterTestCase.cs
@@ -323,7 +323,7 @@ Four score and seven our forefathers brought forth", SymbolShapeHint.FORCE_SQUAR
         [TestCase('1')]
         [TestCase('a')]
         [TestCase('A')]
-        [TestCase('�')]
+        [TestCase('€')]
         public void testCharactersForLengthUntil256RoundTrip(char character)
         {
             var writer = new BarcodeWriter
@@ -438,23 +438,6 @@ Four score and seven our forefathers brought forth", SymbolShapeHint.FORCE_SQUAR
             // No standard symbol matches 48x8, so we expect an exception
             Assert.Throws<ArgumentException>(() =>
                 new DataMatrixWriter().encode(content, BarcodeFormat.DATA_MATRIX, 0, 0, options.Hints));
-        }
-
-        [Test]
-        public void testDMRECapacityBoundaryExactFit()
-        {
-            // DMRE 8x48 has data capacity of 18 codewords
-            // Use a payload that encodes to exactly the capacity (18 codewords)
-            // 18 ASCII characters should need ~18 codewords in ASCII encoding
-            var content = "123456789012345678"; // 18 chars
-            var options = new DatamatrixEncodingOptions
-            {
-                EnableDMRE = true,
-                SymbolShape = SymbolShapeHint.FORCE_RECTANGLE
-            };
-            // With FORCE_RECTANGLE, 18 codewords fits exactly in DMRE 8x48 (cap=18)
-            var matrix = new DataMatrixWriter().encode(content, BarcodeFormat.DATA_MATRIX, 0, 0, options.Hints);
-            Assert.That(matrix, Is.Not.Null);
         }
 
         [Test]


### PR DESCRIPTION
This PR makes Data Matrix Rectangular Extension (DMRE) symbol selection available as an explicit opt-in encoding option.

It is related to PR #597. That PR added DMRE symbols, but the follow-up commit 4d3e585 disabled DMRE selection because it affected existing non-DMRE encoding behavior.

This PR keeps the existing default behavior unchanged:

* DMRE symbols are not selected by default.
* DMRE symbols are only considered when the new hint `EncodeHintType.DATA_MATRIX_DMRE` is explicitly enabled.
* `SymbolShapeHint` keeps its existing meaning. Enabling DMRE does not force rectangular output; it only allows DMRE symbols to be selected when they otherwise match the symbol constraints.

The new option is exposed through `DatamatrixEncodingOptions.EnableDMRE` and passed through the encoder path down to `SymbolInfo.lookup`.

Added tests cover:

* default behavior does not select DMRE,
* opt-in behavior can select a DMRE symbol,
* exact DMRE size constraints work only when DMRE is enabled,
* DMRE size constraints fail without opt-in,
* DMRE round-trip encode/decode.
